### PR TITLE
Fix: Use GitHub App token to bypass branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       tag_created: ${{ steps.check_tag.outputs.created }}
     steps:
       - name: Generate GitHub App Token
-        id: generate-token
+        id: generate_token
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ vars.APP_ID }}
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ steps.generate_token.outputs.token }}
           ref: main
 
       - name: Set up Node.js


### PR DESCRIPTION
Updates release workflow to use GitHub App installation token via actions/create-github-app-token@v2.

This allows the workflow to bypass branch protection rules when pushing version bumps, since the GitHub App is added to the bypass list.

Changes:
- Generate GitHub App token using actions/create-github-app-token@v2
- Use app token for checkout and git operations
- Remove github-actions-x/commit action (not needed)