### PR TITLE
feat: Auto-detect char_brightness based on colorscheme background

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A Neovim plugin that provides VSCode-style side-by-side diff rendering with two-
 }
 ```
 
-> **Note:** The plugin uses your colorscheme's `DiffAdd` and `DiffDelete` for line-level diffs, and auto-brightens them for character-level highlights (assumes dark colorscheme). For light colorschemes, adjust `char_brightness < 1.0`. See [Highlight Groups](#highlight-groups) for details.
+> **Note:** The plugin automatically adapts to your colorscheme's background (dark/light). It uses `DiffAdd` and `DiffDelete` for line-level diffs, and auto-adjusts brightness for character-level highlights (1.4x brighter for dark themes, 0.92x darker for light themes). See [Highlight Groups](#highlight-groups) for customization.
 
 **With custom configuration:**
 ```lua
@@ -55,7 +55,8 @@ A Neovim plugin that provides VSCode-style side-by-side diff rendering with two-
         char_delete = nil,            -- Character-level deletions (nil = auto-derive)
         
         -- Brightness multiplier (only used when char_insert/char_delete are nil)
-        char_brightness = 1.4,        -- Make character highlights 40% brighter
+        -- nil = auto-detect based on background (1.4 for dark, 0.92 for light)
+        char_brightness = nil,        -- Auto-adjust based on your colorscheme
       },
       
       -- Diff view behavior
@@ -303,9 +304,11 @@ The plugin defines highlight groups matching VSCode's diff colors:
 
 **Default behavior:**
 - Uses your colorscheme's `DiffAdd` and `DiffDelete` for line-level highlights
-- Character-level highlights are derived by multiplying brightness by `char_brightness` (default: `1.4`)
-- **Dark colorschemes**: Use `char_brightness > 1.0` to make character highlights brighter (default `1.4` = 40% brighter)
-- **Light colorschemes**: Use `char_brightness < 1.0` to make character highlights darker (e.g., `0.7` = 30% darker)
+- Character-level highlights are auto-adjusted based on `vim.o.background`:
+  - **Dark themes** (`background = "dark"`): Brightness multiplied by `1.4` (40% brighter)
+  - **Light themes** (`background = "light"`): Brightness multiplied by `0.92` (8% darker)
+- This auto-detection works out-of-box for most colorschemes
+- You can override with explicit `char_brightness` value if needed
 
 **Customization examples:**
 
@@ -314,7 +317,7 @@ The plugin defines highlight groups matching VSCode's diff colors:
 highlights = {
   line_insert = "#1d3042",
   line_delete = "#351d2b",
-  char_brightness = 1.5,
+  char_brightness = 1.5,  -- Override auto-detection with explicit value
 }
 
 -- Override character colors explicitly

--- a/lua/vscode-diff/config.lua
+++ b/lua/vscode-diff/config.lua
@@ -14,7 +14,7 @@ M.defaults = {
     char_delete = nil,  -- Character-level deletions (if nil, derived from line_delete with char_brightness)
 
     -- Brightness multiplier for character-level highlights (only used if char_insert/char_delete are nil)
-    -- nil = auto-detect based on background (1.4 for dark, 0.9 for light)
+    -- nil = auto-detect based on background (1.4 for dark, 0.92 for light)
     -- Set explicit value to override: char_brightness = 1.2
     char_brightness = nil,
   },

--- a/lua/vscode-diff/render/highlights.lua
+++ b/lua/vscode-diff/render/highlights.lua
@@ -77,7 +77,7 @@ function M.setup()
   local char_delete_bg
   
   -- Auto-detect brightness based on background if not explicitly set
-  local brightness = opts.char_brightness or (vim.o.background == "light" and 0.9 or 1.4)
+  local brightness = opts.char_brightness or (vim.o.background == "light" and 0.92 or 1.4)
 
   if opts.char_insert then
     -- Explicit char_insert provided - use it directly


### PR DESCRIPTION
## Summary

This PR adds automatic brightness adjustment for character-level diff highlights based on the user's colorscheme background (dark/light), making the plugin work out-of-box for both dark and light themes.

## Key Changes

### Smart Brightness Auto-Detection
- char_brightness now defaults to nil (auto-detect mode)
- Dark themes: Brightness multiplied by 1.4 (40% brighter) - maintains current behavior
- Light themes: Brightness multiplied by 0.92 (8% darker) - makes highlights visible on light backgrounds
- Dynamic detection: Re-evaluated on colorscheme changes
- Override-friendly: Users can still set explicit char_brightness value

### Documentation Updates
- Updated installation note to mention automatic adaptation
- Enhanced Highlight Groups section with auto-detection explanation
- Updated configuration examples to show nil default

## Implementation Details

Design Pattern: Config stores char_brightness = nil (data), highlights.lua handles detection logic (behavior)

Detection: Uses vim.o.background option to determine dark vs light theme

## Benefits

- Works out-of-box for both dark and light colorschemes
- Responds dynamically to colorscheme changes
- No user configuration required
- Users can still override with explicit value

## Commits: 3 commits from dev branch

## Breaking Changes

None. Default behavior for dark themes unchanged. Light theme users gain automatic support.