### PR TITLE
docs: add cmd to lazy.nvim examples for proper lazy loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ https://github.com/user-attachments/assets/64c41f01-dffe-4318-bce4-16eec8de356e
 {
   "esmuellert/vscode-diff.nvim",
   dependencies = { "MunifTanjim/nui.nvim" },
+  cmd = "CodeDiff",
 }
 ```
 
@@ -55,6 +56,7 @@ https://github.com/user-attachments/assets/64c41f01-dffe-4318-bce4-16eec8de356e
 {
   "esmuellert/vscode-diff.nvim",
   dependencies = { "MunifTanjim/nui.nvim" },
+  cmd = "CodeDiff",
   config = function()
     require("vscode-diff").setup({
       -- Highlight configuration


### PR DESCRIPTION
## Summary

Add `cmd = "CodeDiff"` to lazy.nvim installation examples in README.

## Changes

- Added `cmd = "CodeDiff"` to minimal installation example
- Added `cmd = "CodeDiff"` to custom configuration example

## Benefits

- Zero startup overhead (plugin loads only when `:CodeDiff` is invoked)
- Works correctly with NvChad and other lazy-loading setups
- Follows lazy.nvim best practices

Fixes #70