### PR TITLE
fix(tests): support prerelease version format in installer_spec

### DIFF
--- a/tests/installer_spec.lua
+++ b/tests/installer_spec.lua
@@ -25,8 +25,8 @@ describe("Installer Module", function()
     assert.is_not_nil(version.VERSION, "VERSION should be loaded")
     assert.equal("string", type(version.VERSION), "VERSION should be a string")
     assert.is_true(#version.VERSION > 0, "VERSION should not be empty")
-    -- Check version format (e.g., "0.8.0")
-    assert.is_true(version.VERSION:match("^%d+%.%d+%.%d+$") ~= nil, "VERSION should match semantic version format")
+    -- Check version format (e.g., "0.8.0" or "2.0.0-next.0")
+    assert.is_true(version.VERSION:match("^%d+%.%d+%.%d+") ~= nil, "VERSION should match semantic version format")
   end)
 
   -- Test 4: get_lib_path returns correct format


### PR DESCRIPTION
## Summary
Fix version regex test to support prerelease versions like \2.0.0-next.0\.

## Changes
- Changed regex from \^%d+%.%d+%.%d+$\ to \^%d+%.%d+%.%d+\ to allow prerelease suffixes

## Problem
The ext\ branch uses VERSION \2.0.0-next.0\ which failed the strict semver regex that only matched \X.Y.Z\ format.

## Testing
This fix allows both stable (\1.6.2\) and prerelease (\2.0.0-next.0\) versions to pass validation.