### PR TITLE
feat: add synchronous CodeDiff merge for git mergetool

### DIFF
--- a/plugin/vscode-diff.lua
+++ b/plugin/vscode-diff.lua
@@ -28,11 +28,11 @@ local function complete_codediff(arg_lead, cmd_line, cursor_pos)
   
   -- If no args or just ":CodeDiff", suggest subcommands and common revisions
   if #args <= 1 then
-    return { "file", "install", "HEAD", "HEAD~1", "main", "master" }
+    return { "merge", "file", "install", "HEAD", "HEAD~1", "main", "master" }
   end
   
-  -- If first arg is "file", complete with file paths for remaining args
-  if args[2] == "file" then
+  -- If first arg is "merge" or "file", complete with file paths
+  if args[2] == "merge" or args[2] == "file" then
     return vim.fn.getcompletion(arg_lead, "file")
   end
   
@@ -44,12 +44,5 @@ vim.api.nvim_create_user_command("CodeDiff", commands.vscode_diff, {
   nargs = "*",
   bang = true,
   complete = complete_codediff,
-  desc = "VSCode-style diff view: :CodeDiff [<revision>] | file <revision> | file <file_a> <file_b> | install"
-})
-
--- Register merge tool command
-vim.api.nvim_create_user_command("CodeMerge", commands.vscode_merge, {
-  nargs = 1,
-  complete = "file",
-  desc = "VSCode-style merge conflict tool: :CodeMerge <filename>"
+  desc = "VSCode-style diff view: :CodeDiff [<revision>] | merge <file> | file <revision> | install"
 })


### PR DESCRIPTION
## Summary

Adds the `:CodeDiff merge <filename>` subcommand that provides a synchronous 3-way merge view for git mergetool integration.

## Changes

- Add `:CodeDiff merge <filename>` subcommand for 3-way merge view
- Make merge command synchronous with `vim.wait` for git mergetool compatibility
- Extract `setup_conflict_result_window()` helper to reduce code duplication
- Add quote stripping for shell escaping in git mergetool
- Use silent edit with `shortmess` to suppress swap file prompts
- Remove legacy `CodeDiff <filename>` syntax (use `CodeDiff merge` instead)
- Remove `CodeMerge` alias command

## Git Mergetool Configuration

```bash
git config --global merge.tool vscode-diff
git config --global mergetool.vscode-diff.cmd 'nvim "\$MERGED" -c "CodeDiff merge \\"\$MERGED\\""'
```

## Testing

- Tested with `git mergetool --tool=vscode-diff`
- Tested with `nvim <file> -c 'CodeDiff merge <file>'`
- Verified 3-way view with highlights on top buffers
- Verified result buffer reset to BASE content

Closes #97