### PR TITLE
chore: merge main (v1.7.0) into next

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # vscode-diff.nvim
 
+[![Pre-release](https://img.shields.io/github/v/release/esmuellert/vscode-diff.nvim?include_prereleases&label=🚀%20pre-release&color=orange)](https://github.com/esmuellert/vscode-diff.nvim/issues/97)
+
+> **🧪 v2.0.0 Pre-release Available!** The `next` branch includes new features like **Git Merge Tool support**. [Help us test it!](https://github.com/esmuellert/vscode-diff.nvim/issues/97)
+
 A Neovim plugin that provides VSCode-style side-by-side diff rendering with two-tier highlighting.
 
 <div align="center">

--- a/lua/vscode-diff/auto_refresh.lua
+++ b/lua/vscode-diff/auto_refresh.lua
@@ -8,33 +8,41 @@ local core = require("vscode-diff.render.core")
 -- Throttle delay in milliseconds
 local THROTTLE_DELAY_MS = 200
 
--- Track active auto-refresh sessions
+-- Track watched buffers for auto-refresh
 -- Structure: { bufnr = { timer } }
 -- Buffer pair info is retrieved from lifecycle
-local active_sessions = {}
+local watched_buffers = {}
 
 -- Cancel pending timer for a buffer
 local function cancel_timer(bufnr)
-  local session = active_sessions[bufnr]
-  if session and session.timer then
-    vim.fn.timer_stop(session.timer)
-    session.timer = nil
+  local watcher = watched_buffers[bufnr]
+  if watcher and watcher.timer then
+    vim.fn.timer_stop(watcher.timer)
+    watcher.timer = nil
   end
 end
 
 -- Perform diff computation and update decorations
-local function do_diff_update(bufnr)
-  local session = active_sessions[bufnr]
-  if not session then
+-- @param bufnr number: Buffer to update
+-- @param skip_watcher_check boolean: If true, don't require buffer to be in watched_buffers
+local function do_diff_update(bufnr, skip_watcher_check)
+  local watcher = watched_buffers[bufnr]
+  
+  -- Check if buffer is being watched (unless skipped for manual trigger)
+  if not skip_watcher_check and not watcher then
     return
   end
 
-  -- Clear timer reference
-  session.timer = nil
+  -- Clear timer reference if watcher exists
+  if watcher then
+    watcher.timer = nil
+  end
 
   -- Validate buffers still exist
   if not vim.api.nvim_buf_is_valid(bufnr) then
-    active_sessions[bufnr] = nil
+    if watcher then
+      watched_buffers[bufnr] = nil
+    end
     return
   end
   
@@ -42,18 +50,24 @@ local function do_diff_update(bufnr)
   local lifecycle = require('vscode-diff.render.lifecycle')
   local tabpage = lifecycle.find_tabpage_by_buffer(bufnr)
   if not tabpage then
-    active_sessions[bufnr] = nil
+    if watcher then
+      watched_buffers[bufnr] = nil
+    end
     return
   end
   
   local original_bufnr, modified_bufnr = lifecycle.get_buffers(tabpage)
   if not original_bufnr or not modified_bufnr then
-    active_sessions[bufnr] = nil
+    if watcher then
+      watched_buffers[bufnr] = nil
+    end
     return
   end
   
   if not vim.api.nvim_buf_is_valid(original_bufnr) or not vim.api.nvim_buf_is_valid(modified_bufnr) then
-    active_sessions[bufnr] = nil
+    if watcher then
+      watched_buffers[bufnr] = nil
+    end
     return
   end
 
@@ -63,14 +77,11 @@ local function do_diff_update(bufnr)
 
   -- Async diff computation
   vim.schedule(function()
-    -- Check if session was cleaned up while scheduled
-    if not active_sessions[bufnr] then
-      return
-    end
-    
     -- Double-check buffer validity after schedule
     if not vim.api.nvim_buf_is_valid(original_bufnr) or not vim.api.nvim_buf_is_valid(modified_bufnr) then
-      active_sessions[bufnr] = nil
+      if watched_buffers[bufnr] then
+        watched_buffers[bufnr] = nil
+      end
       return
     end
 
@@ -83,6 +94,9 @@ local function do_diff_update(bufnr)
     if not lines_diff then
       return
     end
+
+    -- Update stored diff result in lifecycle (critical for hunk navigation and do/dp)
+    lifecycle.update_diff_result(tabpage, lines_diff)
 
     -- Update decorations on both buffers
     core.render_diff(original_bufnr, modified_bufnr, original_lines, modified_lines, lines_diff)
@@ -161,8 +175,8 @@ end
 
 -- Trigger diff update with throttling
 local function trigger_diff_update(bufnr)
-  local session = active_sessions[bufnr]
-  if not session then
+  local watcher = watched_buffers[bufnr]
+  if not watcher then
     return
   end
 
@@ -170,7 +184,7 @@ local function trigger_diff_update(bufnr)
   cancel_timer(bufnr)
 
   -- Start new timer
-  session.timer = vim.fn.timer_start(THROTTLE_DELAY_MS, function()
+  watcher.timer = vim.fn.timer_start(THROTTLE_DELAY_MS, function()
     do_diff_update(bufnr)
   end)
 end
@@ -179,8 +193,8 @@ end
 -- @param bufnr number: Buffer to watch for changes
 -- Note: Buffer pair info is retrieved from lifecycle when needed
 function M.enable(bufnr)
-  -- Store session info (just timer)
-  active_sessions[bufnr] = {
+  -- Store watcher info (just timer)
+  watched_buffers[bufnr] = {
     timer = nil,
   }
 
@@ -218,7 +232,7 @@ end
 -- Disable auto-refresh for a buffer
 function M.disable(bufnr)
   cancel_timer(bufnr)
-  active_sessions[bufnr] = nil
+  watched_buffers[bufnr] = nil
 
   -- Clear autocmd group
   pcall(vim.api.nvim_del_augroup_by_name, 'vscode_diff_auto_refresh_' .. bufnr)
@@ -341,13 +355,27 @@ function M.refresh_result_now(bufnr)
   do_result_diff_update(bufnr)
 end
 
--- Cleanup all active sessions
+-- Cleanup all watched buffers
 function M.cleanup_all()
-  for bufnr, _ in pairs(active_sessions) do
+  for bufnr, _ in pairs(watched_buffers) do
     M.disable(bufnr)
   end
   for bufnr, _ in pairs(result_timers) do
     M.disable_result(bufnr)
+  end
+end
+
+-- Manually trigger a diff refresh for a buffer (e.g., after programmatic changes)
+-- Works for any buffer in a diff session, even if auto-refresh is not enabled for it
+-- @param bufnr number: Buffer that was changed
+function M.trigger(bufnr)
+  if watched_buffers[bufnr] then
+    -- Buffer has auto-refresh enabled, use throttled update
+    trigger_diff_update(bufnr)
+  else
+    -- Buffer might not have auto-refresh enabled (e.g., virtual buffer)
+    -- Do immediate update, skipping watcher check
+    do_diff_update(bufnr, true)
   end
 end
 

--- a/lua/vscode-diff/config.lua
+++ b/lua/vscode-diff/config.lua
@@ -35,6 +35,8 @@ M.defaults = {
       prev_hunk = "[c",
       next_file = "]f",
       prev_file = "[f",
+      diff_get = "do",              -- Get change from other buffer (like vimdiff)
+      diff_put = "dp",              -- Put change to other buffer (like vimdiff)
     },
     explorer = {
       select = "<CR>",

--- a/lua/vscode-diff/render/view.lua
+++ b/lua/vscode-diff/render/view.lua
@@ -434,6 +434,132 @@ local function setup_all_keymaps(tabpage, original_bufnr, modified_bufnr, is_exp
     explorer.toggle_visibility(explorer_obj)
   end
 
+  -- Helper: Find hunk at cursor position
+  -- Returns the hunk and its index, or nil if cursor is not in a hunk
+  local function find_hunk_at_cursor()
+    local session = lifecycle.get_session(tabpage)
+    if not session or not session.stored_diff_result then return nil, nil end
+    local diff_result = session.stored_diff_result
+    if #diff_result.changes == 0 then return nil, nil end
+
+    local current_buf = vim.api.nvim_get_current_buf()
+    local is_original = current_buf == original_bufnr
+    local cursor = vim.api.nvim_win_get_cursor(0)
+    local current_line = cursor[1]
+
+    for i, mapping in ipairs(diff_result.changes) do
+      local start_line = is_original and mapping.original.start_line or mapping.modified.start_line
+      local end_line = is_original and mapping.original.end_line or mapping.modified.end_line
+      -- Check if cursor is within this hunk (end_line is exclusive)
+      if current_line >= start_line and current_line < end_line then
+        return mapping, i
+      end
+      -- Also match if it's a deletion (empty range) and cursor is at start
+      if start_line == end_line and current_line == start_line then
+        return mapping, i
+      end
+    end
+    return nil, nil
+  end
+
+  -- Helper: Diff get - obtain change from other buffer to current buffer
+  local function diff_get()
+    local session = lifecycle.get_session(tabpage)
+    if not session then return end
+
+    local current_buf = vim.api.nvim_get_current_buf()
+    local is_original = current_buf == original_bufnr
+    local target_buf = current_buf
+    local source_buf = is_original and modified_bufnr or original_bufnr
+
+    -- Check if target buffer is modifiable
+    if not vim.bo[target_buf].modifiable then
+      vim.notify("Buffer is not modifiable", vim.log.levels.WARN)
+      return
+    end
+
+    local hunk, hunk_idx = find_hunk_at_cursor()
+    if not hunk then
+      vim.notify("No hunk at cursor position", vim.log.levels.WARN)
+      return
+    end
+
+    -- Get source and target ranges
+    local source_range = is_original and hunk.modified or hunk.original
+    local target_range = is_original and hunk.original or hunk.modified
+
+    -- Get lines from source buffer
+    local source_lines = vim.api.nvim_buf_get_lines(
+      source_buf,
+      source_range.start_line - 1,
+      source_range.end_line - 1,
+      false
+    )
+
+    -- Replace lines in target buffer
+    vim.api.nvim_buf_set_lines(
+      target_buf,
+      target_range.start_line - 1,
+      target_range.end_line - 1,
+      false,
+      source_lines
+    )
+
+    -- Trigger diff refresh to update highlights
+    auto_refresh.trigger(target_buf)
+
+    vim.api.nvim_echo({{string.format('Obtained hunk %d', hunk_idx), 'None'}}, false, {})
+  end
+
+  -- Helper: Diff put - put change from current buffer to other buffer
+  local function diff_put()
+    local session = lifecycle.get_session(tabpage)
+    if not session then return end
+
+    local current_buf = vim.api.nvim_get_current_buf()
+    local is_original = current_buf == original_bufnr
+    local source_buf = current_buf
+    local target_buf = is_original and modified_bufnr or original_bufnr
+
+    -- Check if target buffer is modifiable
+    if not vim.bo[target_buf].modifiable then
+      vim.notify("Target buffer is not modifiable", vim.log.levels.WARN)
+      return
+    end
+
+    local hunk, hunk_idx = find_hunk_at_cursor()
+    if not hunk then
+      vim.notify("No hunk at cursor position", vim.log.levels.WARN)
+      return
+    end
+
+    -- Get source and target ranges
+    local source_range = is_original and hunk.original or hunk.modified
+    local target_range = is_original and hunk.modified or hunk.original
+
+    -- Get lines from source buffer
+    local source_lines = vim.api.nvim_buf_get_lines(
+      source_buf,
+      source_range.start_line - 1,
+      source_range.end_line - 1,
+      false
+    )
+
+    -- Replace lines in target buffer
+    vim.api.nvim_buf_set_lines(
+      target_buf,
+      target_range.start_line - 1,
+      target_range.end_line - 1,
+      false,
+      source_lines
+    )
+
+    -- Trigger diff refresh to update highlights
+    auto_refresh.trigger(target_buf)
+
+    vim.api.nvim_echo({{string.format('Put hunk %d', hunk_idx), 'None'}}, false, {})
+  end
+
   -- ========================================================================
   -- Bind all keymaps using unified API (one place for all keymaps!)
   -- ========================================================================
@@ -464,6 +590,14 @@ local function setup_all_keymaps(tabpage, original_bufnr, modified_bufnr, is_exp
     if keymaps.prev_file then
       lifecycle.set_tab_keymap(tabpage, 'n', keymaps.prev_file, navigate_prev_file, { desc = 'Previous file in explorer' })
     end
+  end
+
+  -- Diff get/put (do, dp) - like vimdiff
+  if keymaps.diff_get then
+    lifecycle.set_tab_keymap(tabpage, 'n', keymaps.diff_get, diff_get, { desc = 'Get change from other buffer' })
+  end
+  if keymaps.diff_put then
+    lifecycle.set_tab_keymap(tabpage, 'n', keymaps.diff_put, diff_put, { desc = 'Put change to other buffer' })
   end
 end
 

--- a/tests/render/diffget_diffput_spec.lua
+++ b/tests/render/diffget_diffput_spec.lua
@@ -1,0 +1,292 @@
+-- Test: diffget/diffput (do/dp) functionality
+-- Tests for vimdiff-style change transfer between buffers
+
+local view = require("vscode-diff.render.view")
+local diff = require("vscode-diff.diff")
+local highlights = require("vscode-diff.render.highlights")
+local lifecycle = require("vscode-diff.render.lifecycle")
+
+-- Helper to get temp path
+local function get_temp_path(filename)
+  local is_windows = vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1
+  local temp_dir = is_windows and (vim.fn.getenv("TEMP") or "C:\\Windows\\Temp") or "/tmp"
+  local sep = is_windows and "\\" or "/"
+  return temp_dir .. sep .. filename
+end
+
+-- Helper to create diff view and return buffers/windows
+local function create_test_diff_view(original_lines, modified_lines, left_path, right_path)
+  vim.fn.writefile(original_lines, left_path)
+  vim.fn.writefile(modified_lines, right_path)
+
+  local session_config = {
+    mode = "standalone",
+    git_root = nil,
+    original_path = left_path,
+    modified_path = right_path,
+    original_revision = nil,
+    modified_revision = nil,
+  }
+
+  view.create(session_config)
+
+  -- Wait for view setup
+  vim.cmd('redraw')
+  vim.wait(200)
+
+  local tabpage = vim.api.nvim_get_current_tabpage()
+  local wins = vim.api.nvim_tabpage_list_wins(tabpage)
+
+  -- Find which window has which buffer by checking buffer names
+  local original_win, modified_win, original_bufnr, modified_bufnr
+  for _, w in ipairs(wins) do
+    local buf = vim.api.nvim_win_get_buf(w)
+    local name = vim.api.nvim_buf_get_name(buf)
+    if name:match(vim.pesc(left_path)) then
+      original_win = w
+      original_bufnr = buf
+    elseif name:match(vim.pesc(right_path)) then
+      modified_win = w
+      modified_bufnr = buf
+    end
+  end
+
+  return {
+    tabpage = tabpage,
+    original_bufnr = original_bufnr,
+    modified_bufnr = modified_bufnr,
+    original_win = original_win,
+    modified_win = modified_win,
+    left_path = left_path,
+    right_path = right_path,
+  }
+end
+
+describe("Diffget/Diffput", function()
+  before_each(function()
+    highlights.setup()
+  end)
+
+  after_each(function()
+    -- Close all extra tabs
+    while vim.fn.tabpagenr('$') > 1 do
+      vim.cmd('tabclose')
+    end
+  end)
+
+  -- Test 1: diffget obtains change from modified to original buffer
+  it("diffget obtains hunk from modified buffer to original buffer", function()
+    local original = {"line 1", "line 2", "line 3"}
+    local modified = {"line 1", "CHANGED", "line 3"}
+
+    local left_path = get_temp_path("test_diffget_left_1.txt")
+    local right_path = get_temp_path("test_diffget_right_1.txt")
+
+    local ctx = create_test_diff_view(original, modified, left_path, right_path)
+
+    -- Verify initial state
+    local orig_lines = vim.api.nvim_buf_get_lines(ctx.original_bufnr, 0, -1, false)
+    assert.are.same({"line 1", "line 2", "line 3"}, orig_lines)
+
+    -- Move to original window and position cursor on the hunk (line 2)
+    vim.api.nvim_set_current_win(ctx.original_win)
+    vim.api.nvim_win_set_cursor(ctx.original_win, {2, 0})
+
+    -- Simulate diffget by calling the keymap action
+    vim.cmd('normal do')
+    vim.wait(100)
+
+    -- After diffget, original buffer should have the modified content
+    local new_orig_lines = vim.api.nvim_buf_get_lines(ctx.original_bufnr, 0, -1, false)
+    assert.are.same({"line 1", "CHANGED", "line 3"}, new_orig_lines)
+
+    vim.fn.delete(left_path)
+    vim.fn.delete(right_path)
+  end)
+
+  -- Test 2: diffput sends change from original to modified buffer
+  it("diffput sends hunk from original buffer to modified buffer", function()
+    local original = {"line 1", "ORIGINAL", "line 3"}
+    local modified = {"line 1", "line 2", "line 3"}
+
+    local left_path = get_temp_path("test_diffput_left_2.txt")
+    local right_path = get_temp_path("test_diffput_right_2.txt")
+
+    local ctx = create_test_diff_view(original, modified, left_path, right_path)
+
+    -- Verify initial state
+    local mod_lines = vim.api.nvim_buf_get_lines(ctx.modified_bufnr, 0, -1, false)
+    assert.are.same({"line 1", "line 2", "line 3"}, mod_lines)
+
+    -- Move to original window and position cursor on the hunk (line 2)
+    vim.api.nvim_set_current_win(ctx.original_win)
+    vim.api.nvim_win_set_cursor(ctx.original_win, {2, 0})
+
+    -- Simulate diffput
+    vim.cmd('normal dp')
+    vim.wait(100)
+
+    -- After diffput, modified buffer should have the original content
+    local new_mod_lines = vim.api.nvim_buf_get_lines(ctx.modified_bufnr, 0, -1, false)
+    assert.are.same({"line 1", "ORIGINAL", "line 3"}, new_mod_lines)
+
+    vim.fn.delete(left_path)
+    vim.fn.delete(right_path)
+  end)
+
+  -- Test 3: diffget from modified window gets from original
+  it("diffget from modified window obtains from original buffer", function()
+    local original = {"line 1", "FROM_ORIGINAL", "line 3"}
+    local modified = {"line 1", "line 2", "line 3"}
+
+    local left_path = get_temp_path("test_diffget_left_3.txt")
+    local right_path = get_temp_path("test_diffget_right_3.txt")
+
+    local ctx = create_test_diff_view(original, modified, left_path, right_path)
+
+    -- Move to modified window and position cursor on the hunk
+    vim.api.nvim_set_current_win(ctx.modified_win)
+    vim.api.nvim_win_set_cursor(ctx.modified_win, {2, 0})
+
+    -- Simulate diffget from modified side
+    vim.cmd('normal do')
+    vim.wait(100)
+
+    -- After diffget, modified buffer should have content from original
+    local new_mod_lines = vim.api.nvim_buf_get_lines(ctx.modified_bufnr, 0, -1, false)
+    assert.are.same({"line 1", "FROM_ORIGINAL", "line 3"}, new_mod_lines)
+
+    vim.fn.delete(left_path)
+    vim.fn.delete(right_path)
+  end)
+
+  -- Test 4: diffput from modified window sends to original
+  it("diffput from modified window sends to original buffer", function()
+    local original = {"line 1", "line 2", "line 3"}
+    local modified = {"line 1", "FROM_MODIFIED", "line 3"}
+
+    local left_path = get_temp_path("test_diffput_left_4.txt")
+    local right_path = get_temp_path("test_diffput_right_4.txt")
+
+    local ctx = create_test_diff_view(original, modified, left_path, right_path)
+
+    -- Move to modified window and position cursor on the hunk
+    vim.api.nvim_set_current_win(ctx.modified_win)
+    vim.api.nvim_win_set_cursor(ctx.modified_win, {2, 0})
+
+    -- Simulate diffput from modified side
+    vim.cmd('normal dp')
+    vim.wait(100)
+
+    -- After diffput, original buffer should have content from modified
+    local new_orig_lines = vim.api.nvim_buf_get_lines(ctx.original_bufnr, 0, -1, false)
+    assert.are.same({"line 1", "FROM_MODIFIED", "line 3"}, new_orig_lines)
+
+    vim.fn.delete(left_path)
+    vim.fn.delete(right_path)
+  end)
+
+  -- Test 5: Multi-line hunk transfer
+  it("transfers multi-line hunks correctly", function()
+    local original = {"line 1", "old A", "old B", "old C", "line 5"}
+    local modified = {"line 1", "new A", "new B", "line 5"}
+
+    local left_path = get_temp_path("test_multiline_left_5.txt")
+    local right_path = get_temp_path("test_multiline_right_5.txt")
+
+    local ctx = create_test_diff_view(original, modified, left_path, right_path)
+
+    -- Move to original window and position cursor on the hunk
+    vim.api.nvim_set_current_win(ctx.original_win)
+    vim.api.nvim_win_set_cursor(ctx.original_win, {2, 0})
+
+    -- Get change from modified (which has fewer lines)
+    vim.cmd('normal do')
+    vim.wait(100)
+
+    -- Original should now match modified's hunk
+    local new_orig_lines = vim.api.nvim_buf_get_lines(ctx.original_bufnr, 0, -1, false)
+    assert.are.same({"line 1", "new A", "new B", "line 5"}, new_orig_lines)
+
+    vim.fn.delete(left_path)
+    vim.fn.delete(right_path)
+  end)
+
+  -- Test 6: Insertion hunk (empty range on one side)
+  it("handles insertion hunks correctly", function()
+    local original = {"line 1", "line 3"}
+    local modified = {"line 1", "inserted", "line 3"}
+
+    local left_path = get_temp_path("test_insert_left_6.txt")
+    local right_path = get_temp_path("test_insert_right_6.txt")
+
+    local ctx = create_test_diff_view(original, modified, left_path, right_path)
+
+    -- Move to modified window on the inserted line
+    vim.api.nvim_set_current_win(ctx.modified_win)
+    vim.api.nvim_win_set_cursor(ctx.modified_win, {2, 0})
+
+    -- Put the insertion to original
+    vim.cmd('normal dp')
+    vim.wait(100)
+
+    -- Original should now have the inserted line
+    local new_orig_lines = vim.api.nvim_buf_get_lines(ctx.original_bufnr, 0, -1, false)
+    assert.are.same({"line 1", "inserted", "line 3"}, new_orig_lines)
+
+    vim.fn.delete(left_path)
+    vim.fn.delete(right_path)
+  end)
+
+  -- Test 7: Deletion hunk (empty range on one side)
+  it("handles deletion hunks correctly", function()
+    local original = {"line 1", "to_delete", "line 3"}
+    local modified = {"line 1", "line 3"}
+
+    local left_path = get_temp_path("test_delete_left_7.txt")
+    local right_path = get_temp_path("test_delete_right_7.txt")
+
+    local ctx = create_test_diff_view(original, modified, left_path, right_path)
+
+    -- Move to original window on the line to delete
+    vim.api.nvim_set_current_win(ctx.original_win)
+    vim.api.nvim_win_set_cursor(ctx.original_win, {2, 0})
+
+    -- Get the deletion from modified (effectively delete)
+    vim.cmd('normal do')
+    vim.wait(100)
+
+    -- Original should now have the line deleted
+    local new_orig_lines = vim.api.nvim_buf_get_lines(ctx.original_bufnr, 0, -1, false)
+    assert.are.same({"line 1", "line 3"}, new_orig_lines)
+
+    vim.fn.delete(left_path)
+    vim.fn.delete(right_path)
+  end)
+
+  -- Test 8: Multiple hunks - only transfers current hunk
+  it("only transfers the hunk at cursor position", function()
+    local original = {"hunk1_orig", "same", "hunk2_orig"}
+    local modified = {"hunk1_mod", "same", "hunk2_mod"}
+
+    local left_path = get_temp_path("test_multi_hunk_left_8.txt")
+    local right_path = get_temp_path("test_multi_hunk_right_8.txt")
+
+    local ctx = create_test_diff_view(original, modified, left_path, right_path)
+
+    -- Move to original window, position on first hunk
+    vim.api.nvim_set_current_win(ctx.original_win)
+    vim.api.nvim_win_set_cursor(ctx.original_win, {1, 0})
+
+    -- Get only first hunk
+    vim.cmd('normal do')
+    vim.wait(100)
+
+    -- Only first line should change, second hunk unchanged
+    local new_orig_lines = vim.api.nvim_buf_get_lines(ctx.original_bufnr, 0, -1, false)
+    assert.are.same({"hunk1_mod", "same", "hunk2_orig"}, new_orig_lines)
+
+    vim.fn.delete(left_path)
+    vim.fn.delete(right_path)
+  end)
+end)


### PR DESCRIPTION
## Summary
Merge main branch changes into next branch to keep them in sync.

## Changes from main (v1.7.0)
- **feat: add diffget/diffput keymaps (do/dp)** - vimdiff-style keymaps for transferring changes between buffers
- **fix: auto_refresh now updates stored_diff_result** - fixes hunk navigation after buffer edits
- **refactor: rename active_sessions to watched_buffers** - clearer naming to avoid confusion with lifecycle session

## Merge Resolution
Resolved conflicts in:
- `VERSION` - kept next version (2.0.0-next.10)
- `lua/vscode-diff/auto_refresh.lua` - merged main's fixes while preserving next's result buffer refresh code

## Verification
- All 8 diffget/diffput tests pass
- Main's key fix (`lifecycle.update_diff_result`) is present
- Next's result buffer refresh features preserved
- Naming consistency applied throughout