### PR TITLE
feat(conflict): add vimdiff-style 2do/3do keymaps

### DIFF
--- a/lua/vscode-diff/config.lua
+++ b/lua/vscode-diff/config.lua
@@ -51,6 +51,9 @@ M.defaults = {
       discard = "<leader>cx",          -- Discard both, keep base
       next_conflict = "]x",            -- Jump to next conflict
       prev_conflict = "[x",            -- Jump to previous conflict
+      -- Vimdiff-style numbered diffget (from result buffer)
+      diffget_incoming = "2do",        -- Get hunk from incoming (left/theirs) buffer
+      diffget_current = "3do",         -- Get hunk from current (right/ours) buffer
     },
   },
 }

--- a/lua/vscode-diff/render/view.lua
+++ b/lua/vscode-diff/render/view.lua
@@ -315,10 +315,9 @@ local function setup_conflict_result_window(tabpage, session_config, original_wi
   -- Enable auto-refresh for result buffer
   auto_refresh.enable_for_result(result_bufnr)
 
-  -- Setup conflict-specific keymaps
+  -- Initialize conflict tracking (keymaps setup separately after setup_all_keymaps)
   local conflict_actions = require('vscode-diff.render.conflict_actions')
   conflict_actions.initialize_tracking(result_bufnr, conflict_diffs.conflict_blocks)
-  conflict_actions.setup_keymaps(tabpage)
 
   -- Return focus to modified window
   if vim.api.nvim_win_is_valid(modified_win) then
@@ -764,6 +763,9 @@ function M.create(session_config, filetype, on_ready)
               local success = setup_conflict_result_window(tabpage, session_config, original_win, modified_win, base_lines, conflict_diffs, false)
               if success then
                 setup_all_keymaps(tabpage, original_info.bufnr, modified_info.bufnr, false)
+                -- Setup conflict keymaps AFTER setup_all_keymaps to override do/dp
+                local conflict_actions = require('vscode-diff.render.conflict_actions')
+                conflict_actions.setup_keymaps(tabpage)
               end
               
               -- Signal that view is ready
@@ -1104,6 +1106,9 @@ function M.update(tabpage, session_config, auto_scroll_to_first_hunk)
             local success = setup_conflict_result_window(tabpage, session_config, original_win, modified_win, base_lines, conflict_diffs, true)
             if success then
               setup_all_keymaps(tabpage, original_info.bufnr, modified_info.bufnr, is_explorer_mode)
+              -- Setup conflict keymaps AFTER setup_all_keymaps to override do/dp
+              local conflict_actions = require('vscode-diff.render.conflict_actions')
+              conflict_actions.setup_keymaps(tabpage)
             end
           end
         end)


### PR DESCRIPTION
## Summary
Add vimdiff-style `2do` and `3do` keymaps for merge conflict mode, matching diffview.nvim behavior.

## Changes
- Add `diffget_incoming` (`2do`) keymap - get hunk from incoming (left/theirs) buffer
- Add `diffget_current` (`3do`) keymap - get hunk from current (right/ours) buffer  
- Both keymaps work from result buffer only
- Unbind normal mode `do`/`dp` in conflict mode (not applicable to 3-way merge)

## Usage
In merge conflict mode, position cursor in the **result buffer** on a conflict:
- Press `2do` to accept incoming (theirs) version
- Press `3do` to accept current (ours) version

This matches the vimdiff/diffview.nvim convention where numbered commands reference buffer positions.

Closes #104