### PR TITLE
Merge main into next

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vscode-diff.nvim
 
-[![Pre-release](https://img.shields.io/github/v/release/esmuellert/vscode-diff.nvim?include_prereleases&sort=semver&label=🚀%20pre-release&color=orange)](https://github.com/esmuellert/vscode-diff.nvim/issues/97)
+[![Pre-release](https://img.shields.io/github/v/release/esmuellert/vscode-diff.nvim?include_prereleases&sort=semver&label=🚀%20pre-release&color=orange)](https://github.com/esmuellert/vscode-diff.nvim/issues/97) [![Downloads](https://img.shields.io/github/downloads/esmuellert/vscode-diff.nvim/total?label=⬇%20downloads&color=blue)](https://github.com/esmuellert/vscode-diff.nvim/releases)
 
 > **🧪 v2.0.0 Pre-release Available!** The `next` branch includes new features like **Git Merge Tool support**. [Help us test it!](https://github.com/esmuellert/vscode-diff.nvim/issues/97)
 
@@ -103,6 +103,10 @@ https://github.com/user-attachments/assets/64c41f01-dffe-4318-bce4-16eec8de356e
         icons = {
           folder_closed = "",  -- Nerd Font folder icon (customize as needed)
           folder_open = "",    -- Nerd Font folder-open icon
+        },
+        view_mode = "list",    -- "list" or "tree"
+        file_filter = {
+          ignore = {},  -- Glob patterns to hide (e.g., {"*.lock", "dist/*"})
         },
       },
 

--- a/lua/vscode-diff/config.lua
+++ b/lua/vscode-diff/config.lua
@@ -45,6 +45,9 @@ M.defaults = {
       folder_closed = "\u{e5ff}",  -- Nerd Font: folder
       folder_open = "\u{e5fe}",    -- Nerd Font: folder-open
     },
+    file_filter = {
+      ignore = {},  -- Glob patterns to hide (e.g., {"*.lock", "dist/*"})
+    },
   },
 
   -- Keymaps

--- a/lua/vscode-diff/render/explorer/filter.lua
+++ b/lua/vscode-diff/render/explorer/filter.lua
@@ -1,0 +1,79 @@
+local M = {}
+
+-- Convert glob pattern to Lua pattern
+function M.glob_to_pattern(glob)
+  -- Use unique placeholders that won't appear in file paths
+  local DOUBLE_STAR_SLASH = "\001DOUBLESTARSLASH\001"
+  local DOUBLE_STAR = "\001DOUBLESTAR\001"
+  local SINGLE_STAR = "\001SINGLESTAR\001"
+
+  local pattern = glob
+  -- Escape Lua magic characters (except * and ?)
+  pattern = pattern:gsub("([%.%+%-%^%$%(%)%[%]%%])", "%%%1")
+  -- Convert glob wildcards to placeholders first (order matters!)
+  -- Handle **/ specially - it matches zero or more directories
+  pattern = pattern:gsub("%*%*/", DOUBLE_STAR_SLASH)
+  pattern = pattern:gsub("%*%*", DOUBLE_STAR)
+  pattern = pattern:gsub("%*", SINGLE_STAR)
+  pattern = pattern:gsub("%?", ".") -- ? matches single character
+  -- Now convert placeholders to Lua patterns
+  pattern = pattern:gsub(DOUBLE_STAR_SLASH, ".-") -- **/ matches zero or more dirs (including trailing /)
+  pattern = pattern:gsub(DOUBLE_STAR, ".*") -- ** matches anything including /
+  pattern = pattern:gsub(SINGLE_STAR, "[^/]*") -- * matches anything except /
+  return "^" .. pattern .. "$"
+end
+
+-- Check if a file path matches any of the given glob patterns
+-- Follows gitignore-style matching:
+--   *.pb.go      → match basename anywhere
+--   /*.pb.go     → match only in root (leading / anchors)
+--   foo/*.pb.go  → match in foo/ directory
+--   **/*.pb.go   → match anywhere (explicit)
+function M.matches_any_pattern(path, patterns)
+  if not patterns or #patterns == 0 then
+    return false
+  end
+  local basename = path:match("([^/]+)$") or path
+  for _, glob in ipairs(patterns) do
+    local match_target
+    local match_pattern
+
+    if glob:sub(1, 1) == "/" then
+      -- Leading / anchors to root - match full path against pattern without /
+      match_target = path
+      match_pattern = M.glob_to_pattern(glob:sub(2))
+    elseif glob:find("/") then
+      -- Contains / but no leading / - match full path
+      match_target = path
+      match_pattern = M.glob_to_pattern(glob)
+    else
+      -- No / at all - match basename only (matches anywhere)
+      match_target = basename
+      match_pattern = M.glob_to_pattern(glob)
+    end
+
+    if match_target:match(match_pattern) then
+      return true
+    end
+  end
+  return false
+end
+
+-- Filter files based on explorer.file_filter config
+-- Returns files that should be shown (not ignored)
+function M.apply(files, ignore_patterns)
+  if not ignore_patterns or #ignore_patterns == 0 then
+    return files
+  end
+
+  local filtered = {}
+  for _, file in ipairs(files) do
+    if not M.matches_any_pattern(file.path, ignore_patterns) then
+      filtered[#filtered + 1] = file
+    end
+  end
+
+  return filtered
+end
+
+return M

--- a/tests/explorer_file_filter_spec.lua
+++ b/tests/explorer_file_filter_spec.lua
@@ -1,0 +1,185 @@
+-- Test: Explorer File Filter
+-- Validates glob pattern matching for file filtering in explorer
+
+local filter = require("vscode-diff.render.explorer.filter")
+
+-- Use filter module functions
+local glob_to_pattern = filter.glob_to_pattern
+local matches_any_pattern = filter.matches_any_pattern
+
+describe("Explorer File Filter", function()
+  describe("glob_to_pattern", function()
+    it("escapes Lua magic characters", function()
+      local pattern = glob_to_pattern("file.txt")
+      assert.is_true(pattern:find("%.txt") ~= nil, "Should escape dots")
+    end)
+
+    it("converts single star to match non-slash characters", function()
+      local pattern = glob_to_pattern("*.txt")
+      assert.equals("^[^/]*%.txt$", pattern)
+    end)
+
+    it("converts double star to match any characters", function()
+      local pattern = glob_to_pattern("**")
+      assert.equals("^.*$", pattern)
+    end)
+
+    it("converts question mark to match single character", function()
+      local pattern = glob_to_pattern("fo?.txt")
+      assert.equals("^fo.%.txt$", pattern)
+    end)
+
+    it("handles double star with slash for directory matching", function()
+      local pattern = glob_to_pattern("**/foo")
+      assert.equals("^.-foo$", pattern)
+    end)
+  end)
+
+  describe("matches_any_pattern - basename matching (no slash)", function()
+    it("matches file in root directory", function()
+      assert.is_true(matches_any_pattern("foo.pb.go", {"*.pb.go"}))
+    end)
+
+    it("matches file in nested directory", function()
+      assert.is_true(matches_any_pattern("internal/foo/bar.pb.go", {"*.pb.go"}))
+    end)
+
+    it("does not match different extension", function()
+      assert.is_false(matches_any_pattern("foo.go", {"*.pb.go"}))
+    end)
+
+    it("matches with multiple patterns", function()
+      assert.is_true(matches_any_pattern("package-lock.json", {"*.lock", "package-lock.json"}))
+    end)
+  end)
+
+  describe("matches_any_pattern - root anchor (leading slash)", function()
+    it("matches file in root with leading slash", function()
+      assert.is_true(matches_any_pattern("foo.pb.go", {"/*.pb.go"}))
+    end)
+
+    it("does not match nested file with leading slash", function()
+      assert.is_false(matches_any_pattern("internal/foo.pb.go", {"/*.pb.go"}))
+    end)
+
+    it("matches exact root file", function()
+      assert.is_true(matches_any_pattern("README.md", {"/README.md"}))
+    end)
+
+    it("does not match same filename in subdirectory", function()
+      assert.is_false(matches_any_pattern("docs/README.md", {"/README.md"}))
+    end)
+  end)
+
+  describe("matches_any_pattern - directory patterns (contains slash)", function()
+    it("matches file in specific directory", function()
+      assert.is_true(matches_any_pattern("foo/bar.pb.go", {"foo/*.pb.go"}))
+    end)
+
+    it("does not match file in different directory", function()
+      assert.is_false(matches_any_pattern("other/bar.pb.go", {"foo/*.pb.go"}))
+    end)
+
+    it("does not match file in nested subdirectory with single star", function()
+      assert.is_false(matches_any_pattern("foo/sub/bar.pb.go", {"foo/*.pb.go"}))
+    end)
+
+    it("matches nested path exactly", function()
+      assert.is_true(matches_any_pattern("src/components/Button.tsx", {"src/components/*.tsx"}))
+    end)
+  end)
+
+  describe("matches_any_pattern - double star patterns", function()
+    it("matches file in root with **/ prefix", function()
+      assert.is_true(matches_any_pattern("foo.pb.go", {"**/*.pb.go"}))
+    end)
+
+    it("matches deeply nested file with **/ prefix", function()
+      assert.is_true(matches_any_pattern("a/b/c/foo.pb.go", {"**/*.pb.go"}))
+    end)
+
+    it("matches file directly in specified directory", function()
+      assert.is_true(matches_any_pattern("foo/bar.pb.go", {"foo/**/*.pb.go"}))
+    end)
+
+    it("matches deeply nested file under directory", function()
+      assert.is_true(matches_any_pattern("foo/a/b/bar.pb.go", {"foo/**/*.pb.go"}))
+    end)
+
+    it("does not match file in different directory tree", function()
+      assert.is_false(matches_any_pattern("other/bar.pb.go", {"foo/**/*.pb.go"}))
+    end)
+
+    it("matches everything with double star only", function()
+      assert.is_true(matches_any_pattern("any/path/file.txt", {"**"}))
+    end)
+
+    it("matches trailing double star", function()
+      assert.is_true(matches_any_pattern("foo/bar/baz.txt", {"foo/**"}))
+    end)
+  end)
+
+  describe("matches_any_pattern - question mark wildcard", function()
+    it("matches single character", function()
+      assert.is_true(matches_any_pattern("foo.txt", {"fo?.txt"}))
+    end)
+
+    it("does not match multiple characters", function()
+      assert.is_false(matches_any_pattern("fooo.txt", {"fo?.txt"}))
+    end)
+
+    it("does not match zero characters", function()
+      assert.is_false(matches_any_pattern("fo.txt", {"fo?.txt"}))
+    end)
+  end)
+
+  describe("matches_any_pattern - edge cases", function()
+    it("returns false for empty patterns", function()
+      assert.is_false(matches_any_pattern("file.txt", {}))
+    end)
+
+    it("returns false for nil patterns", function()
+      assert.is_false(matches_any_pattern("file.txt", nil))
+    end)
+
+    it("handles files with multiple dots", function()
+      assert.is_true(matches_any_pattern("file.test.spec.js", {"*.spec.js"}))
+    end)
+
+    it("handles patterns with multiple wildcards", function()
+      assert.is_true(matches_any_pattern("test_file_spec.lua", {"test_*_spec.lua"}))
+    end)
+  end)
+
+  describe("matches_any_pattern - real world examples", function()
+    it("filters Go generated files", function()
+      local patterns = {"*.pb.go", "*.gen.go"}
+      assert.is_true(matches_any_pattern("api/v1/service.pb.go", patterns))
+      assert.is_true(matches_any_pattern("internal/models/user.gen.go", patterns))
+      assert.is_false(matches_any_pattern("main.go", patterns))
+    end)
+
+    it("filters lock files", function()
+      local patterns = {"*.lock", "package-lock.json", "yarn.lock"}
+      assert.is_true(matches_any_pattern("Cargo.lock", patterns))
+      assert.is_true(matches_any_pattern("package-lock.json", patterns))
+      assert.is_true(matches_any_pattern("yarn.lock", patterns))
+      assert.is_false(matches_any_pattern("package.json", patterns))
+    end)
+
+    it("filters build output directories", function()
+      local patterns = {"dist/**", "build/**", "node_modules/**"}
+      assert.is_true(matches_any_pattern("dist/bundle.js", patterns))
+      assert.is_true(matches_any_pattern("build/output/main.js", patterns))
+      assert.is_true(matches_any_pattern("node_modules/lodash/index.js", patterns))
+      assert.is_false(matches_any_pattern("src/index.js", patterns))
+    end)
+
+    it("filters minified files", function()
+      local patterns = {"*.min.js", "*.min.css"}
+      assert.is_true(matches_any_pattern("app.min.js", patterns))
+      assert.is_true(matches_any_pattern("assets/styles.min.css", patterns))
+      assert.is_false(matches_any_pattern("app.js", patterns))
+    end)
+  end)
+end)

--- a/tests/run_plenary_tests.sh
+++ b/tests/run_plenary_tests.sh
@@ -33,6 +33,7 @@ SPEC_FILES=(
   "tests/autoscroll_spec.lua"
   "tests/explorer_spec.lua"
   "tests/explorer_staging_spec.lua"
+  "tests/explorer_file_filter_spec.lua"
   "tests/render/semantic_tokens_spec.lua"
   "tests/render/core_spec.lua"
   "tests/render/lifecycle_spec.lua"


### PR DESCRIPTION
## Summary
Syncs `main` branch changes into `next` branch.

## Changes from main
- Added total downloads badge to README
- Added file filter feature for explorer (`filter.lua` module)
- Config option `explorer.file_filter.ignore` for custom ignore patterns

## Merge resolution
Combined both branches' filtering features:
- `next`: merge artifact filtering (`filter_merge_artifacts()`), conflicts group
- `main`: file filter (`filter_files()`)

Both filters are now chained: `filter_merge_artifacts(filter_files(files))`

## Testing
- Resolved conflicts in `VERSION` and `explorer.lua`
- Kept `next` version: `2.0.0-next.15`