### PR TITLE
fix: use checktime instead of edit! to prevent treesitter yield errors

### DIFF
--- a/lua/vscode-diff/render/view.lua
+++ b/lua/vscode-diff/render/view.lua
@@ -864,8 +864,10 @@ function M.update(tabpage, session_config, auto_scroll_to_first_hunk)
         vim.api.nvim_win_set_buf(original_win, original_info.bufnr)
         -- For real files, reload from disk in case it changed
         if not original_is_virtual then
+          -- Use checktime instead of edit! to avoid triggering autocmds
+          -- that can cause treesitter yield errors in scheduled callbacks
           vim.api.nvim_buf_call(original_info.bufnr, function()
-            vim.cmd("silent! edit!")
+            vim.cmd("checktime")
           end)
         end
       else
@@ -912,8 +914,10 @@ function M.update(tabpage, session_config, auto_scroll_to_first_hunk)
         vim.api.nvim_win_set_buf(modified_win, modified_info.bufnr)
         -- For real files, reload from disk in case it changed
         if not modified_is_virtual then
+          -- Use checktime instead of edit! to avoid triggering autocmds
+          -- that can cause treesitter yield errors in scheduled callbacks
           vim.api.nvim_buf_call(modified_info.bufnr, function()
-            vim.cmd("silent! edit!")
+            vim.cmd("checktime")
           end)
         end
       else


### PR DESCRIPTION
## Problem

Fixes treesitter `attempt to yield across C-call boundary` error on Neovim 0.12-dev when opening diff view with markdown files that have render-markdown.nvim enabled.

## Root Cause


## Solution


## Benefits

- ✅ Fixes the treesitter yield error
- ✅ Only reloads if file timestamp changed (more efficient)
- ✅ Triggers fewer autocmds (avoids C-call boundary issue)
- ✅ Semantically correct per Vim documentation
- ✅ Matches patterns used by vim-fugitive, nvim-tree, telescope

## Changes

- Modified 2 locations in `lua/vscode-diff/render/view.lua` (lines 868, 916)
- Changed from `vim.cmd('silent! edit!')` to `vim.cmd('checktime')`
- Added documentation in dev-docs explaining the fix

## Testing

- Tested on Neovim 0.12-dev with render-markdown.nvim
- No more treesitter errors when opening markdown files in diff view
- File reloading still works correctly when files change on disk
- Performance improved by avoiding unnecessary reloads