### PR TITLE
feat: add directory diff

### DIFF
--- a/lua/codediff/core/dir.lua
+++ b/lua/codediff/core/dir.lua
@@ -1,0 +1,112 @@
+-- Directory comparison logic (no git required)
+-- Compares two directories and returns a git-like status result
+-- WARNING: Synchronous recursive scan - large directory trees may block Neovim
+local M = {}
+
+local uv = vim.loop
+
+local function normalize_dir(path)
+  local abs = vim.fn.fnamemodify(path, ":p")
+  abs = abs:gsub("\\", "/")
+  if abs:sub(-1) == "/" then
+    abs = abs:sub(1, -2)
+  end
+  return abs
+end
+
+local function scan_dir(root)
+  local files = {}
+
+  local function recurse(current, rel_prefix)
+    local handle = uv.fs_scandir(current)
+    if not handle then return end
+
+    while true do
+      local name, t = uv.fs_scandir_next(handle)
+      if not name then break end
+
+      local abs = current .. "/" .. name
+      local rel = rel_prefix ~= "" and (rel_prefix .. "/" .. name) or name
+
+      if t == "directory" then
+        recurse(abs, rel)
+      elseif t == "file" then
+        local stat = uv.fs_stat(abs) or {}
+        files[rel] = {
+          path = rel,
+          size = stat.size,
+          mtime = stat.mtime and stat.mtime.sec or nil,
+        }
+      end
+    end
+  end
+
+  recurse(root, "")
+  return files
+end
+
+local function is_modified(a, b)
+  if not a or not b then return false end
+  if a.size ~= b.size then return true end
+  if a.mtime ~= b.mtime then return true end
+  return false
+end
+
+-- Compare two directories and return a git-like status_result.
+-- dir1 = "original", dir2 = "modified"
+-- NOTE: Modification detection is metadata-based (size and mtime only),
+--       not a content hash; this is a fast, best-effort diff.
+function M.diff_directories(dir1, dir2)
+  local root1 = normalize_dir(dir1)
+  local root2 = normalize_dir(dir2)
+
+  local files1 = scan_dir(root1)
+  local files2 = scan_dir(root2)
+
+  local result = {
+    unstaged = {},
+    staged = {},
+    conflicts = {},  -- Empty for dir mode, but consistent with git status shape
+  }
+
+  local seen = {}
+
+  for path, meta1 in pairs(files1) do
+    local meta2 = files2[path]
+    if not meta2 then
+      table.insert(result.unstaged, {
+        path = path,
+        status = "D",
+      })
+    else
+      seen[path] = true
+      if is_modified(meta1, meta2) then
+        table.insert(result.unstaged, {
+          path = path,
+          status = "M",
+        })
+      end
+    end
+  end
+
+  for path, _ in pairs(files2) do
+    if not seen[path] then
+      table.insert(result.unstaged, {
+        path = path,
+        status = "A",
+      })
+    end
+  end
+
+  table.sort(result.unstaged, function(a, b)
+    return a.path < b.path
+  end)
+
+  return {
+    status_result = result,
+    root1 = root1,
+    root2 = root2,
+  }
+end
+
+return M

--- a/lua/codediff/ui/explorer/refresh.lua
+++ b/lua/codediff/ui/explorer/refresh.lua
@@ -9,6 +9,11 @@ M._set_tree_module = function(t) tree_module = t end
 
 -- Setup auto-refresh on file save
 function M.setup_auto_refresh(explorer, tabpage)
+  -- Dir mode: no auto-refresh (static snapshot)
+  if explorer.mode == "dir" then
+    return
+  end
+
   local refresh_timer = nil
   local debounce_ms = 500  -- Wait 500ms after last event
   
@@ -67,6 +72,11 @@ end
 
 -- Refresh explorer with updated git status
 function M.refresh(explorer)
+  -- Dir mode: no refresh (static snapshot)
+  if explorer.mode == "dir" then
+    return
+  end
+
   local git = require('codediff.core.git')
   
   -- Skip refresh if explorer is hidden
@@ -91,7 +101,7 @@ function M.refresh(explorer)
       end
       
       -- Rebuild tree nodes using same structure as create_tree_data
-      local root_nodes = tree_module.create_tree_data(status_result, explorer.git_root, explorer.base_revision)
+      local root_nodes = tree_module.create_tree_data(status_result, explorer.git_root, explorer.base_revision, explorer.mode)
       
       -- Expand all groups
       for _, node in ipairs(root_nodes) do

--- a/lua/codediff/ui/explorer/tree.lua
+++ b/lua/codediff/ui/explorer/tree.lua
@@ -21,7 +21,7 @@ local function filter_files(files)
 end
 
 -- Create tree data structure from git status result
-function M.create_tree_data(status_result, git_root, base_revision)
+function M.create_tree_data(status_result, git_root, base_revision, explorer_mode)
   local explorer_config = config.options.explorer or {}
   local view_mode = explorer_config.view_mode or "list"
 
@@ -35,8 +35,8 @@ function M.create_tree_data(status_result, git_root, base_revision)
   local staged_nodes = create_nodes(staged, git_root, "staged")
   local conflict_nodes = create_nodes(conflicts, git_root, "conflicts")
 
-  if base_revision then
-    -- Revision mode: single group showing all changes
+  if explorer_mode == "dir" or base_revision then
+    -- Dir or revision mode: single group showing all changes
     return {
       Tree.Node({
         text = string.format("Changes (%d)", #unstaged),

--- a/lua/codediff/ui/view/init.lua
+++ b/lua/codediff/ui/view/init.lua
@@ -326,7 +326,17 @@ function M.create(session_config, filetype, on_ready)
     local explorer = require('codediff.ui.explorer')
     local status_result = session_config.explorer_data.status_result
 
-    local explorer_obj = explorer.create(status_result, session_config.git_root, tabpage, nil, session_config.original_revision, session_config.modified_revision)
+    -- Build explorer options for dir mode (detected by presence of dir1/dir2)
+    local explorer_opts = nil
+    if session_config.explorer_data.dir1 and session_config.explorer_data.dir2 then
+      explorer_opts = {
+        mode = "dir",
+        dir1 = session_config.explorer_data.dir1,
+        dir2 = session_config.explorer_data.dir2,
+      }
+    end
+
+    local explorer_obj = explorer.create(status_result, session_config.git_root, tabpage, nil, session_config.original_revision, session_config.modified_revision, explorer_opts)
 
     -- Store explorer reference in lifecycle
     lifecycle.set_explorer(tabpage, explorer_obj)

--- a/tests/dir_spec.lua
+++ b/tests/dir_spec.lua
@@ -1,0 +1,141 @@
+-- Tests for directory comparison (dir.lua)
+local helpers = require('tests.helpers')
+
+describe('dir module', function()
+  local dir_mod
+
+  before_each(function()
+    helpers.ensure_plugin_loaded()
+    dir_mod = require('codediff.core.dir')
+  end)
+
+  after_each(function()
+    helpers.close_extra_tabs()
+  end)
+
+  describe('diff_directories', function()
+    it('should detect added files (only in dir2)', function()
+      local dir1 = helpers.create_temp_dir()
+      local dir2 = helpers.create_temp_dir()
+
+      vim.fn.writefile({ 'content' }, dir2 .. '/new_file.txt')
+
+      local result = dir_mod.diff_directories(dir1, dir2)
+
+      assert.is_not_nil(result.status_result)
+      assert.equals(1, #result.status_result.unstaged)
+      assert.equals('new_file.txt', result.status_result.unstaged[1].path)
+      assert.equals('A', result.status_result.unstaged[1].status)
+
+      vim.fn.delete(dir1, 'rf')
+      vim.fn.delete(dir2, 'rf')
+    end)
+
+    it('should detect deleted files (only in dir1)', function()
+      local dir1 = helpers.create_temp_dir()
+      local dir2 = helpers.create_temp_dir()
+
+      vim.fn.writefile({ 'content' }, dir1 .. '/old_file.txt')
+
+      local result = dir_mod.diff_directories(dir1, dir2)
+
+      assert.is_not_nil(result.status_result)
+      assert.equals(1, #result.status_result.unstaged)
+      assert.equals('old_file.txt', result.status_result.unstaged[1].path)
+      assert.equals('D', result.status_result.unstaged[1].status)
+
+      vim.fn.delete(dir1, 'rf')
+      vim.fn.delete(dir2, 'rf')
+    end)
+
+    it('should detect modified files (different size)', function()
+      local dir1 = helpers.create_temp_dir()
+      local dir2 = helpers.create_temp_dir()
+
+      vim.fn.writefile({ 'short' }, dir1 .. '/file.txt')
+      vim.fn.writefile({ 'much longer content' }, dir2 .. '/file.txt')
+
+      local result = dir_mod.diff_directories(dir1, dir2)
+
+      assert.is_not_nil(result.status_result)
+      assert.equals(1, #result.status_result.unstaged)
+      assert.equals('file.txt', result.status_result.unstaged[1].path)
+      assert.equals('M', result.status_result.unstaged[1].status)
+
+      vim.fn.delete(dir1, 'rf')
+      vim.fn.delete(dir2, 'rf')
+    end)
+
+    it('should return correct structure for identical directories', function()
+      local dir1 = helpers.create_temp_dir()
+      local dir2 = helpers.create_temp_dir()
+
+      vim.fn.writefile({ 'same content' }, dir1 .. '/file.txt')
+      vim.fn.writefile({ 'same content' }, dir2 .. '/file.txt')
+
+      local result = dir_mod.diff_directories(dir1, dir2)
+
+      -- May show as modified due to mtime difference from file creation timing
+      -- Just verify the structure is correct
+      assert.is_not_nil(result.status_result)
+      assert.is_not_nil(result.root1)
+      assert.is_not_nil(result.root2)
+
+      vim.fn.delete(dir1, 'rf')
+      vim.fn.delete(dir2, 'rf')
+    end)
+
+    it('should handle nested directories', function()
+      local dir1 = helpers.create_temp_dir()
+      local dir2 = helpers.create_temp_dir()
+
+      vim.fn.mkdir(dir1 .. '/subdir', 'p')
+      vim.fn.mkdir(dir2 .. '/subdir', 'p')
+      vim.fn.writefile({ 'nested' }, dir2 .. '/subdir/nested.txt')
+
+      local result = dir_mod.diff_directories(dir1, dir2)
+
+      assert.is_not_nil(result.status_result)
+      assert.equals(1, #result.status_result.unstaged)
+      assert.equals('subdir/nested.txt', result.status_result.unstaged[1].path)
+      assert.equals('A', result.status_result.unstaged[1].status)
+
+      vim.fn.delete(dir1, 'rf')
+      vim.fn.delete(dir2, 'rf')
+    end)
+
+    it('should return normalized root paths', function()
+      local dir1 = helpers.create_temp_dir()
+      local dir2 = helpers.create_temp_dir()
+
+      local result = dir_mod.diff_directories(dir1, dir2)
+
+      assert.is_not_nil(result.root1)
+      assert.is_not_nil(result.root2)
+      assert.is_true(result.root1:sub(-1) ~= '/')
+      assert.is_true(result.root2:sub(-1) ~= '/')
+
+      vim.fn.delete(dir1, 'rf')
+      vim.fn.delete(dir2, 'rf')
+    end)
+
+    it('should sort files alphabetically', function()
+      local dir1 = helpers.create_temp_dir()
+      local dir2 = helpers.create_temp_dir()
+
+      vim.fn.writefile({ 'c' }, dir2 .. '/c.txt')
+      vim.fn.writefile({ 'a' }, dir2 .. '/a.txt')
+      vim.fn.writefile({ 'b' }, dir2 .. '/b.txt')
+
+      local result = dir_mod.diff_directories(dir1, dir2)
+
+      assert.equals(3, #result.status_result.unstaged)
+      assert.equals('a.txt', result.status_result.unstaged[1].path)
+      assert.equals('b.txt', result.status_result.unstaged[2].path)
+      assert.equals('c.txt', result.status_result.unstaged[3].path)
+
+      vim.fn.delete(dir1, 'rf')
+      vim.fn.delete(dir2, 'rf')
+    end)
+  end)
+end)

--- a/tests/run_plenary_tests.sh
+++ b/tests/run_plenary_tests.sh
@@ -35,6 +35,7 @@ SPEC_FILES=(
   "tests/explorer_spec.lua"
   "tests/explorer_staging_spec.lua"
   "tests/explorer_file_filter_spec.lua"
+  "tests/dir_spec.lua"
   "tests/render/semantic_tokens_spec.lua"
   "tests/render/core_spec.lua"
   "tests/render/lifecycle_spec.lua"


### PR DESCRIPTION
Adds `:CodeDiff dir1 dir2` to diff two directories without requiring git.

closes #75 

## Usage
- `:CodeDiff /path/to/dir1 /path/to/dir2` (auto-detected)
- `:CodeDiff dir /path/to/dir1 /path/to/dir2` (explicit)

## Changes
- New `dir.lua` module for directory comparison (based on size + mtime)
- Explorer shows A (added), D (deleted), M (modified) status in single "Changes" group
- No git dependency — works with any two directories