### PR TITLE
docs: rebrand vscode-diff.nvim to codediff.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# vscode-diff.nvim
+# codediff.nvim
 
 [![Pre-release](https://img.shields.io/github/v/release/esmuellert/vscode-diff.nvim?include_prereleases&sort=semver&label=🚀%20pre-release&color=orange)](https://github.com/esmuellert/vscode-diff.nvim/issues/97) [![Downloads](https://img.shields.io/github/downloads/esmuellert/vscode-diff.nvim/total?label=⬇%20downloads&color=blue)](https://github.com/esmuellert/vscode-diff.nvim/releases)
 
-> **🧪 v2.0.0 Pre-release Available!** The `next` branch includes new features like **Git Merge Tool support**. [Help us test it!](https://github.com/esmuellert/vscode-diff.nvim/issues/97)
+> **🧪 v2.0.0 Pre-release Available!** The `next` branch includes new features like **Git Merge Tool support**. [Help us test it!](https://github.com/esmuellert/codediff.nvim/issues/97)
 
 A Neovim plugin that provides VSCode-style side-by-side diff rendering with two-tier highlighting.
 
@@ -47,7 +47,7 @@ https://github.com/user-attachments/assets/64c41f01-dffe-4318-bce4-16eec8de356e
 **Minimal installation:**
 ```lua
 {
-  "esmuellert/vscode-diff.nvim",
+  "esmuellert/codediff.nvim",
   dependencies = { "MunifTanjim/nui.nvim" },
   cmd = "CodeDiff",
 }
@@ -58,7 +58,7 @@ https://github.com/user-attachments/assets/64c41f01-dffe-4318-bce4-16eec8de356e
 **With custom configuration:**
 ```lua
 {
-  "esmuellert/vscode-diff.nvim",
+  "esmuellert/codediff.nvim",
   dependencies = { "MunifTanjim/nui.nvim" },
   cmd = "CodeDiff",
   config = function()
@@ -173,12 +173,12 @@ If you prefer to install manually without a plugin manager:
 
 1. **Clone the repository:**
 ```bash
-git clone https://github.com/esmuellert/vscode-diff.nvim ~/.local/share/nvim/vscode-diff.nvim
+git clone https://github.com/esmuellert/codediff.nvim ~/.local/share/nvim/codediff.nvim
 ```
 
 2. **Add to your Neovim runtime path in `init.lua`:**
 ```lua
-vim.opt.rtp:append("~/.local/share/nvim/vscode-diff.nvim")
+vim.opt.rtp:append("~/.local/share/nvim/codediff.nvim")
 ```
 
 3. **Install the C library:**
@@ -190,7 +190,7 @@ The plugin requires a C library binary in the plugin root directory. The plugin 
 
 **Option A: Download from GitHub releases** (recommended)
 
-Download the appropriate binary from the [GitHub releases page](https://github.com/esmuellert/vscode-diff.nvim/releases) and place it in the plugin root directory. Rename it to match the expected format: `libvscode_diff.so`/`.dylib`/`.dll` or `libvscode_diff_<version>.so`/`.dylib`/`.dll`. **Linux users**: If your system lacks OpenMP, also download `libgomp_linux_{arch}_{version}.so.1` and rename it to `libgomp.so.1` in the same directory.
+Download the appropriate binary from the [GitHub releases page](https://github.com/esmuellert/codediff.nvim/releases) and place it in the plugin root directory. Rename it to match the expected format: `libvscode_diff.so`/`.dylib`/`.dll` or `libvscode_diff_<version>.so`/`.dylib`/`.dll`. **Linux users**: If your system lacks OpenMP, also download `libgomp_linux_{arch}_{version}.so.1` and rename it to `libgomp.so.1` in the same directory.
 
 **Option B: Build from source**
 
@@ -442,7 +442,7 @@ For more details on the test structure, see [`tests/README.md`](tests/README.md)
 ### Project Structure
 
 ```
-vscode-diff.nvim/
+codediff.nvim/
 ├── libvscode-diff/        # C diff engine
 │   ├── src/               # C implementation
 │   ├── include/           # C headers

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -174,7 +174,7 @@ build.cmd
 ## Directory Structure
 
 ```
-vscode-diff.nvim/
+codediff.nvim/
 ├── CMakeLists.txt           # Root CMake configuration
 ├── Makefile                 # Convenience wrapper
 ├── libvscode-diff/

--- a/docs/VERSION_MANAGEMENT.md
+++ b/docs/VERSION_MANAGEMENT.md
@@ -120,7 +120,7 @@ CMakeLists.txt reads VERSION file:
 ```cmake
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/VERSION" PROJECT_VERSION)
 string(STRIP "${PROJECT_VERSION}" PROJECT_VERSION)
-project(vscode-diff-nvim VERSION ${PROJECT_VERSION})
+project(codediff-nvim VERSION ${PROJECT_VERSION})
 ```
 
 ### Bump Script

--- a/docs/dependency-distribution.md
+++ b/docs/dependency-distribution.md
@@ -10,7 +10,7 @@ OpenMP parallelization requires `libgomp.so.1`, but not all systems have it inst
 Error: libgomp.so.1: cannot open shared object file: No such file or directory
 ```
 
-This breaks the plugin for users without OpenMP libraries installed (see [Issue #48](https://github.com/esmuellert/vscode-diff.nvim/issues/48)).
+This breaks the plugin for users without OpenMP libraries installed (see [Issue #48](https://github.com/esmuellert/codediff.nvim/issues/48)).
 
 ---
 
@@ -174,7 +174,7 @@ end
 After installation, the plugin folder contains:
 
 ```
-~/.local/share/nvim/lazy/vscode-diff.nvim/
+~/.local/share/nvim/lazy/codediff.nvim/
 ├── libvscode_diff_linux_arm64_0.11.1.so   # Main binary (RUNPATH=$ORIGIN)
 ├── libgomp.so.1                           # Bundled (only if system doesn't have it)
 ├── lua/
@@ -328,8 +328,8 @@ sudo yum install libgomp           # CentOS/RHEL
 sudo pacman -S gcc-libs            # Arch Linux
 
 # Option 2: Manual download
-cd ~/.local/share/nvim/lazy/vscode-diff.nvim
-curl -LO https://github.com/esmuellert/vscode-diff.nvim/releases/download/v{VERSION}/libgomp_linux_{arch}_{VERSION}.so.1
+cd ~/.local/share/nvim/lazy/codediff.nvim
+curl -LO https://github.com/esmuellert/codediff.nvim/releases/download/v{VERSION}/libgomp_linux_{arch}_{VERSION}.so.1
 mv libgomp_linux_* libgomp.so.1
 ```
 
@@ -349,7 +349,7 @@ nvim --headless -c "lua print(pcall(function() require('ffi').load('gomp', true)
 ### Verify plugin is using bundled vs system libgomp
 
 ```bash
-cd ~/.local/share/nvim/lazy/vscode-diff.nvim
+cd ~/.local/share/nvim/lazy/codediff.nvim
 ldd libvscode_diff*.so | grep gomp
 ```
 

--- a/docs/filler-line-algorithm.md
+++ b/docs/filler-line-algorithm.md
@@ -1,6 +1,6 @@
 # Filler Line Algorithm
 
-This document provides a comprehensive explanation of how the filler line insertion mechanism works in vscode-diff.nvim, which replicates VSCode's advanced diff algorithm for side-by-side view alignment.
+This document provides a comprehensive explanation of how the filler line insertion mechanism works in codediff.nvim, which replicates VSCode's advanced diff algorithm for side-by-side view alignment.
 
 ## Table of Contents
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # Test Suite
 
-Integration tests for vscode-diff.nvim using [plenary.nvim](https://github.com/nvim-lua/plenary.nvim).
+Integration tests for codediff.nvim using [plenary.nvim](https://github.com/nvim-lua/plenary.nvim).
 
 ## Test Coverage
 

--- a/tests/completion_spec.lua
+++ b/tests/completion_spec.lua
@@ -10,7 +10,7 @@ describe("Command Completion", function()
       local cwd = vim.fn.getcwd()
       local root = git.get_git_root_sync(cwd)
 
-      -- We're running in the vscode-diff.nvim repo
+      -- We're running in the codediff.nvim repo
       if root then
         assert.equal("string", type(root))
         assert.equal(1, vim.fn.isdirectory(root))

--- a/tests/lazy_spec.lua
+++ b/tests/lazy_spec.lua
@@ -26,7 +26,7 @@ describe("lazy.nvim compatibility", function()
   end)
 
   describe("module loading", function()
-    -- Simulates: { "esmuellert/vscode-diff.nvim", cmd = "CodeDiff" }
+    -- Simulates: { "esmuellert/codediff.nvim", cmd = "CodeDiff" }
 
     it("should load codediff module", function()
       reset_module_cache()
@@ -54,7 +54,7 @@ describe("lazy.nvim compatibility", function()
   end)
 
   describe("setup with opts", function()
-    -- Simulates: { "esmuellert/vscode-diff.nvim", opts = {} }
+    -- Simulates: { "esmuellert/codediff.nvim", opts = {} }
 
     it("should work with codediff.setup({})", function()
       reset_module_cache()

--- a/tests/run_plenary_tests.sh
+++ b/tests/run_plenary_tests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Test runner for vscode-diff.nvim using plenary.nvim
+# Test runner for codediff.nvim using plenary.nvim
 
 set -e
 
@@ -14,7 +14,7 @@ NC='\033[0m'
 
 echo ""
 echo "╔══════════════════════════════════════════════════════════════╗"
-echo "║          vscode-diff.nvim Test Suite (Plenary)               ║"
+echo "║          codediff.nvim Test Suite (Plenary)                  ║"
 echo "╚══════════════════════════════════════════════════════════════╝"
 echo ""
 


### PR DESCRIPTION
## Summary
Rebrand the plugin from `vscode-diff.nvim` to `codediff.nvim`.

## Changes
- Update README.md with new plugin name and GitHub URLs
- Update docs/ references to codediff.nvim
- Update tests/ comments and banners

## Notes
After merging, the repository can be renamed on GitHub to complete the rebranding.