### PR TITLE
fix(hl): fix missing link handle for default hl

### DIFF
--- a/lua/vscode-diff/render/highlights.lua
+++ b/lua/vscode-diff/render/highlights.lua
@@ -45,7 +45,7 @@ local function resolve_color(value, default_fallback)
       return { bg = r * 65536 + g * 256 + b }
     else
       -- Assume it's a highlight group name
-      local hl = vim.api.nvim_get_hl(0, { name = value })
+      local hl = vim.api.nvim_get_hl(0, { name = value, link = false })
       return { bg = hl.bg or default_fallback }
     end
   elseif type(value) == "number" then


### PR DESCRIPTION
**Problem**: Currently we cannot handle link highlight groups  (like `vim.api.nvim_set_hl(0, "DiffDelete", { link = "diffRemoved" })` ) correctly, and then it will always fallback to default highlight.

**Solution**: Adding `link = false` to opts of `vim.api.nvim_get_hl`, we can get the effective highlight definition.

current:
![CleanShot X 2026-01-04 17 18 02](https://github.com/user-attachments/assets/1d917060-209c-439d-8293-22492883451a)
after fix:
![CleanShot X 2026-01-04 17 17 13](https://github.com/user-attachments/assets/e2d49bab-efb5-4465-b77c-0db30f0a4154)
