### PR TITLE
feat(explorer): hide temp files of mergetool for newer git versions

### DIFF
--- a/lua/codediff/ui/explorer/nodes.lua
+++ b/lua/codediff/ui/explorer/nodes.lua
@@ -13,6 +13,14 @@ local MERGE_ARTIFACT_PATTERNS = {
   "%.BASE%.",          -- file.BASE.xxxxx
   "%.LOCAL%.",         -- file.LOCAL.xxxxx
   "%.REMOTE%.",        -- file.REMOTE.xxxxx
+  "_BACKUP_%d+%.",     -- file_BACKUP_xxxxx.ext
+  "_BASE_%d+%.",       -- file_BASE_xxxxx.ext
+  "_LOCAL_%d+%.",      -- file_LOCAL_xxxxx.ext
+  "_REMOTE_%d+%.",     -- file_REMOTE_xxxxx.ext
+  "_BACKUP_%d+$",      -- file_BACKUP_xxxxx
+  "_BASE_%d+$",        -- file_BASE_xxxxx
+  "_LOCAL_%d+$",       -- file_LOCAL_xxxxx
+  "_REMOTE_%d+$",      -- file_REMOTE_xxxxx
 }
 
 -- Status symbols and colors


### PR DESCRIPTION
I believed this is the reason that @celarye said the option did not work in the [issue](https://github.com/esmuellert/codediff.nvim/issues/105#issuecomment-3664393922). I'm not sure the exact version of this behavioral change. I'm currently using Git 2.52.0.

The newer versions of Git have different syntax for temp files of mergetool:

- filename_BACKUP_xxxxx.extension
- filename_BASE_xxxxx.extension
- filename_LOCAL_xxxxx.extension
- filename_REMOTE_xxxxx.extension

If a conflict file does not have the extension, the temp files would be:

- filename_BACKUP_xxxxx
- filename_BASE_xxxxx
- filename_LOCAL_xxxxx
- filename_REMOTE_xxxxx

Because the limitation of lua pattern match, I have to list these patterns inside the MERGE_ARTIFACT_TABLE one by one.