### PR TITLE
fix: use explicit split positioning to ignore user's splitright setting

### DIFF
--- a/lua/codediff/ui/view/init.lua
+++ b/lua/codediff/ui/view/init.lua
@@ -48,8 +48,10 @@ function M.create(session_config, filetype, on_ready)
 
   local original_win, modified_win, original_info, modified_info, initial_buf
 
-  -- Split command: "vsplit" puts new window right, "leftabove vsplit" puts it left
-  local split_cmd = config.options.diff.original_position == "right" and "leftabove vsplit" or "vsplit"
+  -- Split command: Use explicit positioning to ignore user's splitright setting
+  -- "rightbelow vsplit" puts new window on RIGHT, "leftabove vsplit" puts it on LEFT
+  -- We want modified (new) on RIGHT when original_position == "left"
+  local split_cmd = config.options.diff.original_position == "right" and "leftabove vsplit" or "rightbelow vsplit"
 
   if is_explorer_placeholder then
     -- Explorer mode: Create empty split panes, skip buffer loading


### PR DESCRIPTION
## Summary
- Fix inconsistent diff layout for users without `set splitright` in their config
- Replace implicit `vsplit` with explicit `rightbelow vsplit` to guarantee consistent behavior

## Problem
The previous code used `vsplit` which respects the user's `splitright` option:
- Users with `set splitright` (like the maintainer) got correct layout
- Users with default `set nosplitright` got inverted layout (modified on left, original on right)

## Solution
Use explicit positioning commands that ignore `splitright`:
- `rightbelow vsplit` - always puts new window on RIGHT
- `leftabove vsplit` - always puts new window on LEFT

## Testing
- All 194 tests pass
- Verified with `--clean` config (no user settings)

## Credit
Issue reported by daliusd_ on Reddit