### PR TITLE
feat(view): Add toggle staged keymap support

### DIFF
--- a/lua/codediff/ui/explorer/actions.lua
+++ b/lua/codediff/ui/explorer/actions.lua
@@ -173,12 +173,13 @@ function M.toggle_stage_entry(explorer, tree)
   end
 
   local node = tree:get_node()
-  if not node or not node.data or node.data.type == "group" or node.data.type == "directory" then
+
+  if not node or not node.data then
     return
   end
 
-  local file_path = node.data.path
-  local group = node.data.group
+  local file_path = node.data.path or explorer.current_file_path
+  local group = node.data.group or explorer.current_file_group
 
   if group == "staged" then
     -- Unstage file

--- a/lua/codediff/ui/view/keymaps.lua
+++ b/lua/codediff/ui/view/keymaps.lua
@@ -231,6 +231,17 @@ function M.setup_all_keymaps(tabpage, original_bufnr, modified_bufnr, is_explore
     vim.api.nvim_echo({ { string.format("Put hunk %d", hunk_idx), "None" } }, false, {})
   end
 
+  -- Helper: Toggle staged
+  local function toggle_staged()
+    local explorer_obj = lifecycle.get_explorer(tabpage)
+    if not explorer_obj then
+      vim.notify("No explorer found for this tab", vim.log.levels.WARN)
+      return
+    end
+    local explorer = require("codediff.ui.explorer")
+    explorer.toggle_stage_entry(explorer_obj, explorer_obj.tree)
+  end
+
   -- ========================================================================
   -- Bind all keymaps using unified API (one place for all keymaps!)
   -- ========================================================================
@@ -269,6 +280,11 @@ function M.setup_all_keymaps(tabpage, original_bufnr, modified_bufnr, is_explore
   end
   if keymaps.diff_put then
     lifecycle.set_tab_keymap(tabpage, "n", keymaps.diff_put, diff_put, { desc = "Put change to other buffer" })
+  end
+
+  -- Toggle stage/unstage (- key, like diffview)
+  if config.options.keymaps.explorer.toggle_stage then
+    lifecycle.set_tab_keymap(tabpage, "n", config.options.keymaps.explorer.toggle_stage, toggle_staged, { desc = "Toggle stage/unstage" })
   end
 end
 


### PR DESCRIPTION
Yes it uses the same config key as the explorer keymap, I could refactor that if you want, it can use the old position if it exists in the config or else use a shared keymap `options.keymaps.toggle_stage`?