### PR TITLE
Explorer & History Mode: Add Quickfix List Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,16 @@ https://github.com/user-attachments/assets/64c41f01-dffe-4318-bce4-16eec8de356e
 - Neovim >= 0.7.0 (for Lua FFI support; 0.10+ recommended for vim.system)
 - Git (for git diff features)
 - `curl` or `wget` (for automatic binary download)
-- `nui.nvim` (for explorer UI)
+
+**Optional:**
+- `nui.nvim` - for tree-style file explorer sidebar (default)
 
 **No compiler required!** The plugin automatically downloads pre-built binaries from GitHub releases.
 
 ### Using lazy.nvim
 
 **Minimal installation:**
+
 ```lua
 {
   "esmuellert/codediff.nvim",
@@ -57,7 +60,8 @@ https://github.com/user-attachments/assets/64c41f01-dffe-4318-bce4-16eec8de356e
 ```lua
 {
   "esmuellert/codediff.nvim",
-  dependencies = { "MunifTanjim/nui.nvim" },
+  -- required if using backend = "nui"
+  -- dependencies = { "MunifTanjim/nui.nvim" },
   cmd = "CodeDiff",
   opts = {
     -- Highlight configuration
@@ -95,10 +99,11 @@ https://github.com/user-attachments/assets/64c41f01-dffe-4318-bce4-16eec8de356e
 
     -- Explorer panel configuration
     explorer = {
-      position = "left",  -- "left" or "bottom"
-      width = 40,         -- Width when position is "left" (columns)
-      height = 15,        -- Height when position is "bottom" (lines)
-      indent_markers = true,  -- Show indent markers in tree view (│, ├, └)
+      backend = "quickfix",  -- "quickfix" (no deps) or "nui" (requires nui.nvim)
+      position = "left",  -- "left" or "bottom" (nui backend only)
+      width = 40,         -- Width when position is "left" (nui backend only)
+      height = 15,        -- Height when position is "bottom" (nui backend only)
+      indent_markers = true,  -- Show indent markers in tree view (nui backend only)
       initial_focus = "explorer",  -- Initial focus: "explorer", "original", or "modified"
       icons = {
         folder_closed = "",  -- Nerd Font folder icon (customize as needed)
@@ -112,11 +117,12 @@ https://github.com/user-attachments/assets/64c41f01-dffe-4318-bce4-16eec8de356e
 
     -- History panel configuration (for :CodeDiff history)
     history = {
-      position = "bottom",  -- "left" or "bottom" (default: bottom)
-      width = 40,           -- Width when position is "left" (columns)
-      height = 15,          -- Height when position is "bottom" (lines)
+      backend = "quickfix",  -- "quickfix" (no deps) or "nui" (requires nui.nvim)
+      position = "bottom",  -- "left" or "bottom" (nui backend only)
+      width = 40,           -- Width when position is "left" (nui backend only)
+      height = 15,          -- Height when position is "bottom" (nui backend only)
       initial_focus = "history",  -- Initial focus: "history", "original", or "modified"
-      view_mode = "list",   -- "list" or "tree" for files under commits
+      view_mode = "list",   -- "list" or "tree" for files under commits (nui backend only)
     },
 
     -- Keymaps in diff view

--- a/lua/codediff/config.lua
+++ b/lua/codediff/config.lua
@@ -38,7 +38,8 @@ M.defaults = {
 
   -- Explorer panel configuration
   explorer = {
-    position = "left", -- "left" or "bottom"
+    backend = "quickfix", -- "quickfix" (no deps) or "nui" (requires nui.nvim)
+    position = "left", -- "left" or "bottom" (nui backend only)
     width = 40, -- Width when position is "left" (columns)
     height = 15, -- Height when position is "bottom" (lines)
     view_mode = "list", -- "list" (flat file list) or "tree" (directory tree)
@@ -55,7 +56,8 @@ M.defaults = {
 
   -- History panel configuration (for :CodeDiff history)
   history = {
-    position = "bottom", -- "left" or "bottom" (default: bottom)
+    backend = "quickfix", -- "quickfix" (no deps) or "nui" (requires nui.nvim)
+    position = "bottom", -- "left" or "bottom" (nui backend only)
     width = 40, -- Width when position is "left" (columns)
     height = 15, -- Height when position is "bottom" (lines)
     initial_focus = "history", -- Initial focus: "history", "original", or "modified"

--- a/lua/codediff/ui/explorer/quickfix.lua
+++ b/lua/codediff/ui/explorer/quickfix.lua
@@ -1,0 +1,167 @@
+local M = {}
+
+local view = require("codediff.ui.view")
+local lifecycle = require("codediff.ui.lifecycle")
+local config = require("codediff.config")
+
+local function status_to_prefix(status)
+  local map = {
+    M = "[M]",
+    A = "[A]",
+    D = "[D]",
+    ["??"] = "[?]",
+    UU = "[C]",
+    AA = "[C]",
+    DD = "[C]",
+  }
+  return map[status] or "[" .. status .. "]"
+end
+
+local function build_qf_items(status_result, git_root)
+  local items = {}
+
+  if status_result.conflicts and #status_result.conflicts > 0 then
+    for _, file in ipairs(status_result.conflicts) do
+      table.insert(items, {
+        filename = git_root and (git_root .. "/" .. file.path) or file.path,
+        text = status_to_prefix(file.status) .. " " .. file.path,
+        user_data = { path = file.path, status = file.status, group = "conflicts" },
+      })
+    end
+  end
+
+  for _, file in ipairs(status_result.unstaged) do
+    table.insert(items, {
+      filename = git_root and (git_root .. "/" .. file.path) or file.path,
+      text = status_to_prefix(file.status) .. " " .. file.path,
+      user_data = { path = file.path, status = file.status, group = "unstaged" },
+    })
+  end
+
+  for _, file in ipairs(status_result.staged) do
+    table.insert(items, {
+      filename = git_root and (git_root .. "/" .. file.path) or file.path,
+      text = status_to_prefix(file.status) .. " staged: " .. file.path,
+      user_data = { path = file.path, status = file.status, group = "staged" },
+    })
+  end
+
+  return items
+end
+
+function M.create(status_result, git_root, tabpage, base_revision, target_revision, opts)
+  opts = opts or {}
+
+  local items = build_qf_items(status_result, git_root)
+  if #items == 0 then
+    vim.notify("No changes to show", vim.log.levels.INFO)
+    return nil
+  end
+
+  vim.fn.setqflist({}, "r", {
+    title = "CodeDiff: Changed Files",
+    items = items,
+  })
+
+  local group = vim.api.nvim_create_augroup("CodeDiffQuickfix_" .. tabpage, { clear = true })
+
+  vim.api.nvim_create_autocmd("BufReadCmd", {
+    group = group,
+    pattern = "codediff://*",
+    callback = function(ev)
+      local path = ev.file:match("^codediff://(.+)$")
+      if not path then
+        return
+      end
+
+      local qflist = vim.fn.getqflist({ items = 1 }).items
+      for _, item in ipairs(qflist) do
+        local data = item.user_data
+        if data and data.path == path then
+          M.select_file(tabpage, git_root, data, base_revision, target_revision, opts)
+          break
+        end
+      end
+    end,
+  })
+
+  vim.cmd("copen")
+
+  local qf_bufnr = vim.api.nvim_get_current_buf()
+  vim.keymap.set("n", "<CR>", function()
+    local idx = vim.fn.line(".")
+    local qflist = vim.fn.getqflist({ items = 1 }).items
+    local item = qflist[idx]
+    if item and item.user_data then
+      M.select_file(tabpage, git_root, item.user_data, base_revision, target_revision, opts)
+    end
+  end, { buffer = qf_bufnr, desc = "Open diff for selected file" })
+
+  vim.keymap.set("n", "q", function()
+    vim.cmd("cclose")
+  end, { buffer = qf_bufnr, desc = "Close quickfix" })
+
+  if #items > 0 then
+    local first = items[1].user_data
+    M.select_file(tabpage, git_root, first, base_revision, target_revision, opts)
+  end
+
+  return {
+    tabpage = tabpage,
+    git_root = git_root,
+    base_revision = base_revision,
+    target_revision = target_revision,
+    status_result = status_result,
+  }
+end
+
+function M.select_file(tabpage, git_root, file_data, base_revision, target_revision, opts)
+  opts = opts or {}
+  local file_path = file_data.path
+  local group = file_data.group
+  local status = file_data.status
+
+  local original_revision, modified_revision
+  local original_path, modified_path
+  local is_conflict = (group == "conflicts")
+
+  if is_conflict then
+    original_revision = ":3"
+    modified_revision = ":2"
+    original_path = file_path
+    modified_path = file_path
+  elseif group == "staged" then
+    original_revision = base_revision or "HEAD"
+    modified_revision = ":0"
+    original_path = file_path
+    modified_path = file_path
+  else
+    original_revision = base_revision or "HEAD"
+    modified_revision = (target_revision == "WORKING" or not target_revision) and nil or target_revision
+    original_path = file_path
+    modified_path = git_root and (git_root .. "/" .. file_path) or file_path
+  end
+
+  if status == "A" then
+    original_revision = nil
+    original_path = nil
+  elseif status == "D" then
+    modified_revision = nil
+    modified_path = nil
+  end
+
+  local session = lifecycle.get_session(tabpage)
+  if session then
+    view.update(tabpage, {
+      mode = "explorer",
+      git_root = git_root,
+      original_path = original_path or "",
+      modified_path = modified_path or "",
+      original_revision = original_revision,
+      modified_revision = modified_revision,
+      conflict = is_conflict,
+    }, true)
+  end
+end
+
+return M

--- a/lua/codediff/ui/history/quickfix.lua
+++ b/lua/codediff/ui/history/quickfix.lua
@@ -1,0 +1,101 @@
+local M = {}
+
+local view = require("codediff.ui.view")
+local lifecycle = require("codediff.ui.lifecycle")
+
+local function build_qf_items(commits, git_root, opts)
+  local items = {}
+  local file_path = opts and opts.file_path
+
+  for _, commit in ipairs(commits) do
+    local text = string.format("%s %s - %s (%s)",
+      commit.short_hash,
+      commit.subject:sub(1, 50),
+      commit.author,
+      commit.date_relative
+    )
+    if commit.ref_names then
+      text = text .. " [" .. commit.ref_names .. "]"
+    end
+
+    table.insert(items, {
+      filename = git_root and (git_root .. "/" .. (file_path or "")) or "",
+      text = text,
+      user_data = {
+        hash = commit.hash,
+        short_hash = commit.short_hash,
+        file_path = file_path or commit.file_path,
+      },
+    })
+  end
+
+  return items
+end
+
+function M.create(commits, git_root, tabpage, opts)
+  opts = opts or {}
+
+  local items = build_qf_items(commits, git_root, opts)
+  if #items == 0 then
+    vim.notify("No commits to show", vim.log.levels.INFO)
+    return nil
+  end
+
+  vim.fn.setqflist({}, "r", {
+    title = "CodeDiff: Commit History",
+    items = items,
+  })
+
+  vim.cmd("copen")
+
+  local qf_bufnr = vim.api.nvim_get_current_buf()
+  vim.keymap.set("n", "<CR>", function()
+    local idx = vim.fn.line(".")
+    local qflist = vim.fn.getqflist({ items = 1 }).items
+    local item = qflist[idx]
+    if item and item.user_data then
+      M.select_commit(tabpage, git_root, item.user_data, opts)
+    end
+  end, { buffer = qf_bufnr, desc = "Open diff for selected commit" })
+
+  vim.keymap.set("n", "q", function()
+    vim.cmd("cclose")
+  end, { buffer = qf_bufnr, desc = "Close quickfix" })
+
+  if #items > 0 then
+    local first = items[1].user_data
+    M.select_commit(tabpage, git_root, first, opts)
+  end
+
+  return {
+    tabpage = tabpage,
+    git_root = git_root,
+    commits = commits,
+  }
+end
+
+function M.select_commit(tabpage, git_root, commit_data, opts)
+  opts = opts or {}
+  local hash = commit_data.hash
+  local file_path = commit_data.file_path or opts.file_path
+
+  local session = lifecycle.get_session(tabpage)
+  if not session then
+    return
+  end
+
+  if file_path then
+    view.update(tabpage, {
+      mode = "history",
+      git_root = git_root,
+      original_path = file_path,
+      modified_path = file_path,
+      original_revision = hash .. "^",
+      modified_revision = hash,
+    }, true)
+  else
+    vim.notify("Select a file to view diff (no file path for commit)", vim.log.levels.INFO)
+  end
+end
+
+return M


### PR DESCRIPTION
Makes `nui.nvim` (resolving #203) optional by supporting another explorer & history backend: quickfix.

Changes include:

- backwards-compatible config updates
- warning to migrate to new config `explorer.backend` structure ^[1]
```lua
require("codediff").setup({
  explorer = { backend = "nui" },
  history = { backend = "nui" },
})
```
- quickfix mode itself
- doc updates to reflect changes

Note that docs assume `nui.nvim` is used by default as it is used in the aesthetic README showcases that show the full "potential" of `codediff.nvim`. 

[1] It'd be a good idea for the explorer backend to be modular - extending out the config to a table of options and making users aware of this is a common practice I find in plugins such as `blink.nvim`.