### PR TITLE
fix: scroll to selected line range in history mode (#246)

### DIFF
--- a/lua/codediff/commands.lua
+++ b/lua/codediff/commands.lua
@@ -239,6 +239,7 @@ local function handle_history(range, file_path, flags, line_range)
             range = range,
             file_path = history_opts.path,
             base_revision = flags.base,
+            line_range = line_range,
           },
         }
 

--- a/lua/codediff/ui/history/render.lua
+++ b/lua/codediff/ui/history/render.lua
@@ -96,6 +96,7 @@ end
 function M.create(commits, git_root, tabpage, width, opts)
   opts = opts or {}
   local base_revision = opts.base_revision
+  local line_range = opts.line_range
 
   -- Get history panel position and size from config (separate from explorer)
   local history_config = config.options.history or {}
@@ -292,6 +293,7 @@ function M.create(commits, git_root, tabpage, width, opts)
         modified_path = file_path,
         original_revision = target_hash,
         modified_revision = commit_hash,
+        line_range = line_range,
       }
       view.update(tabpage, session_config, true)
     end)

--- a/lua/codediff/ui/view/init.lua
+++ b/lua/codediff/ui/view/init.lua
@@ -30,7 +30,8 @@ local setup_all_keymaps = view_keymaps.setup_all_keymaps
 ---@field modified_revision string?
 ---@field conflict boolean? For merge conflict mode: render both sides against base
 ---@field explorer_data table? For explorer mode: { status_result }
----@field history_data table? For history mode: { commits, range, file_path }
+---@field history_data table? For history mode: { commits, range, file_path, line_range }
+---@field line_range table? For history line-range mode: { start_line, end_line }
 
 ---@param session_config SessionConfig Session configuration
 ---@param filetype? string Optional filetype for syntax highlighting
@@ -431,6 +432,7 @@ function M.create(session_config, filetype, on_ready)
       range = session_config.history_data.range,
       file_path = session_config.history_data.file_path,
       base_revision = session_config.history_data.base_revision,
+      line_range = session_config.history_data.line_range,
     })
 
     -- Store history panel reference in lifecycle (reuse explorer slot)
@@ -620,7 +622,8 @@ function M.update(tabpage, session_config, auto_scroll_to_first_hunk)
         modified_is_virtual,
         original_win,
         modified_win,
-        should_auto_scroll
+        should_auto_scroll,
+        session_config.line_range
       )
 
       if lines_diff then


### PR DESCRIPTION
## Summary

Fixes #246 — `:'<,'>CodeDiff history` now scrolls to the selected region instead of always jumping to the first change in the file.

## Changes

- Store `line_range` from visual selection in `history_data` so it persists across commit navigations
- Pass `line_range` through the history panel → view update → render pipeline
- In `compute_and_render`, when `line_range` is provided, scroll to the first hunk overlapping the selected range instead of `changes[1]`
- Falls back to the range start line if no hunk overlaps

## Testing

- All existing tests pass (installer test failure is pre-existing)
- E2E scenario validated the plumbing works end-to-end
- Normal `:CodeDiff history` (without visual selection) is unaffected — `line_range` is `nil` and the original scroll behavior applies