### PR TITLE
feat: clear 'Last file' and 'First file' msg when moving to next/prev file

### DIFF
--- a/lua/codediff/ui/explorer/actions.lua
+++ b/lua/codediff/ui/explorer/actions.lua
@@ -50,6 +50,8 @@ function M.navigate_next(explorer)
   if current_index >= #all_files and not config.options.diff.cycle_next_file then
     vim.api.nvim_echo({ { string.format("Last file (%d of %d)", #all_files, #all_files), "WarningMsg" } }, false, {})
     return
+  else
+    vim.api.nvim_echo({}, false, {})
   end
   local next_index = current_index % #all_files + 1
   local next_file = all_files[next_index]
@@ -101,6 +103,8 @@ function M.navigate_prev(explorer)
   if current_index <= 1 and not config.options.diff.cycle_next_file then
     vim.api.nvim_echo({ { string.format("First file (1 of %d)", #all_files), "WarningMsg" } }, false, {})
     return
+  else
+    vim.api.nvim_echo({}, false, {})
   end
   local prev_index = current_index - 2
   if prev_index < 0 then

--- a/lua/codediff/ui/history/render.lua
+++ b/lua/codediff/ui/history/render.lua
@@ -450,6 +450,8 @@ function M.navigate_next(history)
   if current_index >= #all_files and not config.options.diff.cycle_next_file then
     vim.api.nvim_echo({ { string.format("Last file (%d of %d)", #all_files, #all_files), "WarningMsg" } }, false, {})
     return
+  else
+    vim.api.nvim_echo({}, false, {})
   end
 
   local next_index = current_index % #all_files + 1
@@ -494,6 +496,8 @@ function M.navigate_prev(history)
   if current_index <= 1 and not config.options.diff.cycle_next_file then
     vim.api.nvim_echo({ { string.format("First file (1 of %d)", #all_files), "WarningMsg" } }, false, {})
     return
+  else
+    vim.api.nvim_echo({}, false, {})
   end
 
   local prev_index = current_index - 2


### PR DESCRIPTION
This avoids always showing "Last file" or "First file" messages when the last or first file is reached.

Related to: https://github.com/esmuellert/codediff.nvim/pull/241

btw, thanks a lot for addressing https://github.com/esmuellert/codediff.nvim/issues/219