### PR TITLE
fix: set buffer names on explorer, history, and placeholder buffers

### DIFF
--- a/lua/codediff/ui/explorer/render.lua
+++ b/lua/codediff/ui/explorer/render.lua
@@ -51,6 +51,7 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
 
   -- Mount split first to get bufnr
   split:mount()
+  pcall(vim.api.nvim_buf_set_name, split.bufnr, "CodeDiff Explorer [" .. tabpage .. "]")
 
   -- Track selected path and group for highlighting
   local selected_path = nil

--- a/lua/codediff/ui/history/render.lua
+++ b/lua/codediff/ui/history/render.lua
@@ -133,6 +133,7 @@ function M.create(commits, git_root, tabpage, width, opts)
   })
 
   split:mount()
+  pcall(vim.api.nvim_buf_set_name, split.bufnr, "CodeDiff History [" .. tabpage .. "]")
 
   -- Track selected commit and file
   local selected_commit = nil

--- a/lua/codediff/ui/view/init.lua
+++ b/lua/codediff/ui/view/init.lua
@@ -70,6 +70,8 @@ function M.create(session_config, filetype, on_ready)
     local mod_scratch = vim.api.nvim_create_buf(false, true)
     vim.bo[orig_scratch].buftype = "nofile"
     vim.bo[mod_scratch].buftype = "nofile"
+    pcall(vim.api.nvim_buf_set_name, orig_scratch, "CodeDiff " .. tabpage .. ".1")
+    pcall(vim.api.nvim_buf_set_name, mod_scratch, "CodeDiff " .. tabpage .. ".2")
     vim.api.nvim_win_set_buf(original_win, orig_scratch)
     vim.api.nvim_win_set_buf(modified_win, mod_scratch)
 


### PR DESCRIPTION
## Summary

Fix `[No Name]` showing in tabline/lualine for codediff-managed buffers.

## Changes

Set descriptive buffer names on all codediff buffers that previously had no name:

- **Scratch diff panes** (placeholder before file selection): `CodeDiff <id>.1` / `CodeDiff <id>.2`
- **Explorer panel**: `CodeDiff Explorer [<id>]`
- **History panel**: `CodeDiff History [<id>]`

Virtual file buffers (`codediff:///...`) already display correctly via `:t` (shows the filename).

## Benefits

- Tabline and tab plugins (lualine, bufferline) now show meaningful names for all codediff tabs
- No behavioral changes — only display names added
- Minimal change: 4 lines across 3 files