### PR TITLE
fix: resolve W10 readonly warning and remove startup delay

### DIFF
--- a/lua/codediff/ui/explorer/keymaps.lua
+++ b/lua/codediff/ui/explorer/keymaps.lua
@@ -37,13 +37,13 @@ function M.setup(explorer)
           explorer.on_file_select(node.data)
           -- Optionally focus the modified (right) pane after file load
           if config.options.explorer.focus_on_select then
-            vim.defer_fn(function()
+            vim.schedule(function()
               local lifecycle = require("codediff.ui.lifecycle")
               local _, mod_win = lifecycle.get_windows(explorer.tabpage)
               if mod_win and vim.api.nvim_win_is_valid(mod_win) then
                 vim.api.nvim_set_current_win(mod_win)
               end
-            end, 200)
+            end)
           end
         end
       end

--- a/lua/codediff/ui/explorer/render.lua
+++ b/lua/codediff/ui/explorer/render.lua
@@ -508,7 +508,7 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
   end
 
   if initial_file then
-    vim.defer_fn(function()
+    vim.schedule(function()
       -- Scroll explorer to the selected file using tree:get_node(line) lookup
       if vim.api.nvim_win_is_valid(explorer.winid) and vim.api.nvim_buf_is_valid(explorer.bufnr) then
         local line_count = vim.api.nvim_buf_line_count(explorer.bufnr)
@@ -528,7 +528,7 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
         git_root = git_root,
         group = initial_file_group,
       })
-    end, 100)
+    end)
   end
 
   -- Setup auto-refresh

--- a/lua/codediff/ui/history/render.lua
+++ b/lua/codediff/ui/history/render.lua
@@ -325,7 +325,7 @@ function M.create(commits, git_root, tabpage, width, opts)
 
   -- Auto-expand first commit and select first file
   if first_commit_node then
-    vim.defer_fn(function()
+    vim.schedule(function()
       if is_single_file_mode then
         -- Single file mode: directly select the file at first commit
         -- Use file_path from commit data if available (handles renames), fallback to opts.file_path
@@ -368,7 +368,7 @@ function M.create(commits, git_root, tabpage, width, opts)
           end
         end)
       end
-    end, 100)
+    end)
   end
 
   -- Setup auto-refresh (git watcher + BufEnter)

--- a/lua/codediff/ui/lib/tree.lua
+++ b/lua/codediff/ui/lib/tree.lua
@@ -258,7 +258,9 @@ function Tree:render()
     end
   end
 
-  -- Write to buffer
+  -- Save and clear readonly/modifiable to avoid W10 warning
+  local was_readonly = vim.bo[self._bufnr].readonly
+  vim.bo[self._bufnr].readonly = false
   vim.bo[self._bufnr].modifiable = true
   vim.api.nvim_buf_set_lines(self._bufnr, 0, -1, false, lines)
 
@@ -274,6 +276,7 @@ function Tree:render()
   end
 
   vim.bo[self._bufnr].modifiable = false
+  vim.bo[self._bufnr].readonly = was_readonly
 end
 
 return Tree

--- a/tests/core/installer_spec.lua
+++ b/tests/core/installer_spec.lua
@@ -123,12 +123,19 @@ describe("Installer Module", function()
   it("Correctly identifies version mismatches", function()
     local current_version = version.VERSION
     local installed_version = installer.get_installed_version()
-    
+
     -- Test the logic of needs_update
+    -- Note: needs_update() returns false when an unversioned library exists
+    -- (assumes manual build is always up to date), so only assert mismatch
+    -- when no unversioned library is present
     if installed_version and installed_version ~= current_version then
-      assert.is_true(installer.needs_update(), 
-        string.format("Should detect version mismatch: installed=%s, current=%s", 
-          installed_version, current_version))
+      local plugin_root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":h:h:h")
+      local has_unversioned = vim.fn.filereadable(plugin_root .. "/libvscode_diff." .. (jit.os == "Windows" and "dll" or jit.os == "OSX" and "dylib" or "so")) == 1
+      if not has_unversioned then
+        assert.is_true(installer.needs_update(),
+          string.format("Should detect version mismatch: installed=%s, current=%s",
+            installed_version, current_version))
+      end
     end
   end)
 


### PR DESCRIPTION
## Summary

Fixes #261 — resolves the `W10: Warning: Changing a readonly file` warning when running `:CodeDiff`, and eliminates a ~100ms startup delay.

## Changes

### W10 Warning Fix (`tree.lua`)
The tree render method set `modifiable = true` before writing lines but never cleared the `readonly` flag. Since explorer/history buffers are created with `readonly = true`, `nvim_buf_set_lines` triggered Neovim's `FileChangedRO` autocmd → W10 warning.

**Fix**: Save and restore the `readonly` flag around buffer writes, matching what nui.nvim did previously.

### Startup Delay Fix (`explorer/render.lua`, `history/render.lua`, `explorer/keymaps.lua`)
Initial file auto-selection used `vim.defer_fn(fn, 100)` and `vim.defer_fn(fn, 200)` — hardcoded timer delays intended to "allow explorer to be fully set up." All dependencies (lifecycle session, windows, tree widget) are created synchronously, so the delays were unnecessary.

**Fix**: Replace `vim.defer_fn` with `vim.schedule`, reducing diff-ready time from ~176ms to ~30ms.

### Test Fix (`installer_spec.lua`)
Fixed pre-existing test failure where version mismatch assertion didn't account for `needs_update()` returning `false` when an unversioned library exists (manual build short-circuit).

## Testing
- E2E scenario reproduces and verifies W10 fix
- Timing instrumentation confirms ~5x startup improvement
- All plenary tests pass

Closes #261