### PR TITLE
feat: customizable explorer highlight groups

### DIFF
--- a/doc/codediff.txt
+++ b/doc/codediff.txt
@@ -235,6 +235,22 @@ Customization examples:
   }
 <
 
+Explorer & history git status highlights (customizable):
+
+- CodeDiffStatusAdded       Added files (links to DiagnosticOk)
+- CodeDiffStatusModified    Modified files (links to DiagnosticWarn)
+- CodeDiffStatusDeleted     Deleted files (links to DiagnosticError)
+- CodeDiffStatusRenamed     Renamed files (links to DiagnosticInfo)
+- CodeDiffStatusUntracked   Untracked files (links to DiagnosticInfo)
+- CodeDiffStatusConflict    Conflicting files (links to DiagnosticError)
+- CodeDiffExplorerSelected  Selected file background (links to Visual)
+
+Override in your config or colorscheme:
+>lua
+  vim.api.nvim_set_hl(0, "CodeDiffStatusModified", { fg = "#e2c08d" })
+  vim.api.nvim_set_hl(0, "CodeDiffStatusAdded", { fg = "#3fb950" })
+<
+
 ==============================================================================
 LUA API                                                   *codediff-lua-api*
 

--- a/lua/codediff/ui/explorer/nodes.lua
+++ b/lua/codediff/ui/explorer/nodes.lua
@@ -25,11 +25,11 @@ local MERGE_ARTIFACT_PATTERNS = {
 
 -- Status symbols and colors
 local STATUS_SYMBOLS = {
-  M = { symbol = "M", color = "DiagnosticWarn" },
-  A = { symbol = "A", color = "DiagnosticOk" },
-  D = { symbol = "D", color = "DiagnosticError" },
-  ["??"] = { symbol = "??", color = "DiagnosticInfo" },
-  ["!"] = { symbol = "!", color = "DiagnosticError" }, -- Merge conflict
+  M = { symbol = "M", color = "CodeDiffStatusModified" },
+  A = { symbol = "A", color = "CodeDiffStatusAdded" },
+  D = { symbol = "D", color = "CodeDiffStatusDeleted" },
+  ["??"] = { symbol = "??", color = "CodeDiffStatusUntracked" },
+  ["!"] = { symbol = "!", color = "CodeDiffStatusConflict" },
 }
 
 -- Indent marker characters (neo-tree style)

--- a/lua/codediff/ui/highlights.lua
+++ b/lua/codediff/ui/highlights.lua
@@ -146,6 +146,14 @@ function M.setup()
     default = true,
   })
 
+  -- Explorer git status highlights (customizable, like diffview.nvim)
+  vim.api.nvim_set_hl(0, "CodeDiffStatusAdded", { link = "DiagnosticOk", default = true })
+  vim.api.nvim_set_hl(0, "CodeDiffStatusModified", { link = "DiagnosticWarn", default = true })
+  vim.api.nvim_set_hl(0, "CodeDiffStatusDeleted", { link = "DiagnosticError", default = true })
+  vim.api.nvim_set_hl(0, "CodeDiffStatusRenamed", { link = "DiagnosticInfo", default = true })
+  vim.api.nvim_set_hl(0, "CodeDiffStatusUntracked", { link = "DiagnosticInfo", default = true })
+  vim.api.nvim_set_hl(0, "CodeDiffStatusConflict", { link = "DiagnosticError", default = true })
+
   -- Helper to check if a highlight group exists and has foreground color
   local function hl_exists(name)
     local ok, hl = pcall(vim.api.nvim_get_hl, 0, { name = name, link = false })

--- a/lua/codediff/ui/history/nodes.lua
+++ b/lua/codediff/ui/history/nodes.lua
@@ -8,10 +8,10 @@ local config = require("codediff.config")
 
 -- Status symbols and colors (reuse from explorer)
 local STATUS_SYMBOLS = {
-  M = { symbol = "M", color = "DiagnosticWarn" },
-  A = { symbol = "A", color = "DiagnosticOk" },
-  D = { symbol = "D", color = "DiagnosticError" },
-  R = { symbol = "R", color = "DiagnosticInfo" },
+  M = { symbol = "M", color = "CodeDiffStatusModified" },
+  A = { symbol = "A", color = "CodeDiffStatusAdded" },
+  D = { symbol = "D", color = "CodeDiffStatusDeleted" },
+  R = { symbol = "R", color = "CodeDiffStatusRenamed" },
 }
 
 -- File icons (basic fallback)


### PR DESCRIPTION
## Summary

Add named `CodeDiffStatus*` highlight groups for git status colors in the explorer and history panels.

## Changes

- Added 6 customizable highlight groups: `CodeDiffStatusAdded`, `CodeDiffStatusModified`, `CodeDiffStatusDeleted`, `CodeDiffStatusRenamed`, `CodeDiffStatusUntracked`, `CodeDiffStatusConflict`
- Default links preserve existing colors (`DiagnosticOk`, `DiagnosticWarn`, `DiagnosticError`, `DiagnosticInfo`)
- Users can now override individual status colors without affecting global highlights
- Updated vimdoc with highlight group reference and override examples

## Usage

```lua
-- Override in your config or colorscheme
vim.api.nvim_set_hl(0, "CodeDiffStatusModified", { fg = "#e2c08d" })
vim.api.nvim_set_hl(0, "CodeDiffStatusAdded", { fg = "#3fb950" })
```

Closes #128