### PR TITLE
Restore to previously commited changes

### DIFF
--- a/lua/codediff/core/git.lua
+++ b/lua/codediff/core/git.lua
@@ -714,7 +714,7 @@ end
 -- callback: function(err)
 function M.restore_file(git_root, rel_path, callback)
   -- git restore is preferred (Git 2.23+), fallback to checkout
-  run_git_async({ "restore", "--", rel_path }, { cwd = git_root }, function(err, _)
+  run_git_async({ "restore", "--source=origin/HEAD", "--", rel_path }, { cwd = git_root }, function(err, _)
     if err then
       -- Fallback to git checkout for older git versions
       run_git_async({ "checkout", "--", rel_path }, { cwd = git_root }, function(err2, _)


### PR DESCRIPTION
When reviewing commits with `CodeDiff origin/HEAD...` it would be nice to revert commited files/changes. I could see no way of making this change beyond hard coding the restore source. This behaviour did work in diffview.nvim - it looked like there were two path for restoration, one for history used a commit hash: https://github.com/sindrets/diffview.nvim/blob/4516612fe98ff56ae0415a259ff6361a89419b0a/lua/diffview/scene/views/file_history/listeners.lua#L227

Which would be more robust than this approach but I couldn't spot where the commit was stored looking at the code.