### PR TITLE
fix: set default layout to side-by-side (not inline)

### DIFF
--- a/lua/codediff/config.lua
+++ b/lua/codediff/config.lua
@@ -29,7 +29,7 @@ M.defaults = {
 
   -- Diff view behavior
   diff = {
-    layout = "inline", -- Diff layout: "side-by-side" or "inline"
+    layout = "side-by-side", -- Diff layout: "side-by-side" or "inline"
     disable_inlay_hints = true, -- Disable inlay hints in diff windows for cleaner view
     max_computation_time_ms = 5000, -- Maximum time for diff computation (5 seconds, VSCode default)
     ignore_trim_whitespace = false, -- Ignore leading/trailing whitespace changes (like diffopt+=iwhite)


### PR DESCRIPTION
The default layout was accidentally set to `"inline"` in the inline diff feature commit. This would break existing users' workflows by switching them to the new layout without opt-in.

Fixes the default back to `"side-by-side"`.