### PR TITLE
Add --inline and --side-by-side flags to :CodeDiff

### DIFF
--- a/lua/codediff/commands.lua
+++ b/lua/codediff/commands.lua
@@ -27,7 +27,7 @@ end
 -- @param revision string: The git revision (e.g., "HEAD", commit hash, branch name) to compare the current file against.
 -- @param revision2 string?: Optional second revision. If provided, compares revision vs revision2.
 -- This function chains async git operations to get git root, resolve revision to hash, and get file content.
-local function handle_git_diff(revision, revision2)
+local function handle_git_diff(revision, revision2, layout)
   local current_file = vim.api.nvim_buf_get_name(0)
 
   if current_file == "" then
@@ -83,6 +83,7 @@ local function handle_git_diff(revision, revision2)
                   modified_path = modified_path,
                   original_revision = commit_hash,
                   modified_revision = commit_hash2,
+                  layout = layout,
                 }
                 view.create(session_config, filetype)
               end)
@@ -99,6 +100,7 @@ local function handle_git_diff(revision, revision2)
               modified_path = relative_path,
               original_revision = commit_hash,
               modified_revision = "WORKING",
+              layout = layout,
             }
             view.create(session_config, filetype)
           end)
@@ -108,7 +110,7 @@ local function handle_git_diff(revision, revision2)
   end)
 end
 
-local function handle_file_diff(file_a, file_b)
+local function handle_file_diff(file_a, file_b, layout)
   -- Determine filetype from first file
   local filetype = vim.filetype.match({ filename = file_a }) or ""
 
@@ -121,11 +123,12 @@ local function handle_file_diff(file_a, file_b)
     modified_path = file_b,
     original_revision = nil,
     modified_revision = nil,
+    layout = layout,
   }
   view.create(session_config, filetype)
 end
 
-local function handle_dir_diff(dir1, dir2)
+local function handle_dir_diff(dir1, dir2, layout)
   local dir_mod = require("codediff.core.dir")
 
   -- Expand ~ and environment variables in paths
@@ -157,6 +160,7 @@ local function handle_dir_diff(dir1, dir2)
     modified_path = diff.root2,
     original_revision = nil,
     modified_revision = nil,
+    layout = layout,
     explorer_data = {
       status_result = status_result,
     },
@@ -169,7 +173,7 @@ end
 -- range: git range (e.g., "origin/main..HEAD", "HEAD~10")
 -- file_path: optional file path to filter history
 -- line_range: optional {start, end} for line-range history (git log -L)
-local function handle_history(range, file_path, flags, line_range)
+local function handle_history(range, file_path, flags, line_range, layout)
   flags = flags or {} -- Default to empty table for backward compat
   local current_buf = vim.api.nvim_get_current_buf()
   local current_file = vim.api.nvim_buf_get_name(current_buf)
@@ -234,6 +238,7 @@ local function handle_history(range, file_path, flags, line_range)
           modified_path = "",
           original_revision = nil,
           modified_revision = nil,
+          layout = layout,
           history_data = {
             commits = commits,
             range = range,
@@ -279,7 +284,7 @@ local function handle_history(range, file_path, flags, line_range)
   end
 end
 
-local function handle_explorer(revision, revision2)
+local function handle_explorer(revision, revision2, layout)
   -- Try buffer path first (consistent with original behavior), fallback to cwd
   local current_buf = vim.api.nvim_get_current_buf()
   local current_file = vim.api.nvim_buf_get_name(current_buf)
@@ -316,6 +321,7 @@ local function handle_explorer(revision, revision2)
           modified_path = "",
           original_revision = original_rev,
           modified_revision = modified_rev,
+          layout = layout,
           explorer_data = {
             status_result = status_result,
             focus_file = focus_file, -- Focus on current file if changed
@@ -410,7 +416,7 @@ local function handle_explorer(revision, revision2)
 end
 
 -- Wrapper for merge-base explorer mode: computes merge-base first, then opens explorer
-local function handle_explorer_merge_base(base_rev, target_rev)
+local function handle_explorer_merge_base(base_rev, target_rev, layout)
   local current_buf = vim.api.nvim_get_current_buf()
   local current_file = vim.api.nvim_buf_get_name(current_buf)
   local cwd = vim.fn.getcwd()
@@ -438,9 +444,9 @@ local function handle_explorer_merge_base(base_rev, target_rev)
       -- Schedule the explorer call to run in main context (handle_explorer uses nvim_get_current_buf)
       vim.schedule(function()
         if target_rev then
-          handle_explorer(merge_base_hash, target_rev)
+          handle_explorer(merge_base_hash, target_rev, layout)
         else
-          handle_explorer(merge_base_hash) -- vs working tree
+          handle_explorer(merge_base_hash, nil, layout)
         end
       end)
     end)
@@ -448,7 +454,7 @@ local function handle_explorer_merge_base(base_rev, target_rev)
 end
 
 -- Wrapper for merge-base single-file diff: computes merge-base first, then opens diff
-local function handle_git_diff_merge_base(base_rev, target_rev)
+local function handle_git_diff_merge_base(base_rev, target_rev, layout)
   local current_file = vim.api.nvim_buf_get_name(0)
   if current_file == "" then
     vim.notify("Current buffer is not a file", vim.log.levels.ERROR)
@@ -474,7 +480,7 @@ local function handle_git_diff_merge_base(base_rev, target_rev)
 
       -- Schedule the diff call to run in main context (handle_git_diff uses nvim_buf_get_name)
       vim.schedule(function()
-        handle_git_diff(merge_base_hash, target_rev)
+        handle_git_diff(merge_base_hash, target_rev, layout)
       end)
     end)
   end)
@@ -578,11 +584,22 @@ function M.vscode_diff(opts)
     return
   end
 
-  local args = opts.fargs
+  -- Pre-parse layout flags; strip them so subcommand dispatch sees clean args
+  local layout = nil
+  local args = {}
+  for _, arg in ipairs(opts.fargs) do
+    if arg == "--inline" then
+      layout = "inline"
+    elseif arg == "--side-by-side" then
+      layout = "side-by-side"
+    else
+      table.insert(args, arg)
+    end
+  end
 
   if #args == 0 then
     -- :CodeDiff without arguments opens explorer mode
-    handle_explorer()
+    handle_explorer(nil, nil, layout)
     return
   end
 
@@ -591,7 +608,7 @@ function M.vscode_diff(opts)
     local expanded1 = vim.fn.expand(args[1])
     local expanded2 = vim.fn.expand(args[2])
     if vim.fn.isdirectory(expanded1) == 1 and vim.fn.isdirectory(expanded2) == 1 then
-      handle_dir_diff(expanded1, expanded2)
+      handle_dir_diff(expanded1, expanded2, layout)
       return
     end
   end
@@ -610,10 +627,10 @@ function M.vscode_diff(opts)
       -- Check for triple-dot syntax: :CodeDiff file main...
       local base, target = parse_triple_dot(args[2])
       if base then
-        handle_git_diff_merge_base(base, target)
+        handle_git_diff_merge_base(base, target, layout)
       else
         -- :CodeDiff file HEAD
-        handle_git_diff(args[2])
+        handle_git_diff(args[2], nil, layout)
       end
     elseif #args == 3 then
       -- Check if arguments are files or revisions
@@ -623,10 +640,10 @@ function M.vscode_diff(opts)
       -- If both are readable files, treat as file diff
       if vim.fn.filereadable(arg1) == 1 and vim.fn.filereadable(arg2) == 1 then
         -- :CodeDiff file file_a.txt file_b.txt
-        handle_file_diff(arg1, arg2)
+        handle_file_diff(arg1, arg2, layout)
       else
         -- Assume revisions: :CodeDiff file main HEAD
-        handle_git_diff(arg1, arg2)
+        handle_git_diff(arg1, arg2, layout)
       end
     else
       vim.notify("Usage: :CodeDiff file <revision> [revision2] OR :CodeDiff file <file_a> <file_b>", vim.log.levels.ERROR)
@@ -637,7 +654,7 @@ function M.vscode_diff(opts)
       vim.notify("Usage: :CodeDiff dir <dir1> <dir2>", vim.log.levels.ERROR)
       return
     end
-    handle_dir_diff(args[2], args[3])
+    handle_dir_diff(args[2], args[3], layout)
   elseif subcommand == "history" then
     -- :CodeDiff history [range] [file] [--reverse|-r]
     -- :'<,'>CodeDiff history                  - line-range history for selection
@@ -715,7 +732,7 @@ function M.vscode_diff(opts)
       end
     end
 
-    handle_history(range, file_path, flags, line_range)
+    handle_history(range, file_path, flags, line_range, layout)
   elseif subcommand == "install" or subcommand == "install!" then
     -- :CodeDiff install or :CodeDiff install!
     -- Handle both :CodeDiff! install and :CodeDiff install!
@@ -738,11 +755,11 @@ function M.vscode_diff(opts)
     -- Check for triple-dot syntax: :CodeDiff main...
     local base, target = parse_triple_dot(subcommand)
     if base then
-      handle_explorer_merge_base(base, target)
+      handle_explorer_merge_base(base, target, layout)
     elseif #args == 2 then
-      handle_explorer(args[1], args[2])
+      handle_explorer(args[1], args[2], layout)
     else
-      handle_explorer(subcommand)
+      handle_explorer(subcommand, nil, layout)
     end
   end
 end

--- a/lua/codediff/core/args.lua
+++ b/lua/codediff/core/args.lua
@@ -23,7 +23,7 @@ function M.parse_args(args, flag_spec)
       for long_name, spec in pairs(flag_spec) do
         if arg == long_name or (spec.short and arg == spec.short) then
           is_flag = true
-          local flag_key = long_name:gsub("^%-%-", "")
+          local flag_key = long_name:gsub("^%-%-", ""):gsub("%-", "_")
 
           if spec.type == "boolean" then
             flags[flag_key] = true

--- a/lua/codediff/ui/view/init.lua
+++ b/lua/codediff/ui/view/init.lua
@@ -11,6 +11,7 @@ local lifecycle_initialized = false
 -- Resolve effective layout: conflict always uses side-by-side
 local function get_layout(session_config)
   if session_config.conflict then return "side-by-side" end
+  if session_config.layout then return session_config.layout end
   return config.options.diff.layout
 end
 
@@ -22,6 +23,7 @@ end
 ---@field original_revision string?
 ---@field modified_revision string?
 ---@field conflict boolean? For merge conflict mode: render both sides against base
+---@field layout "side-by-side"|"inline"? Optional per-invocation layout override
 ---@field explorer_data table? For explorer mode: { status_result }
 ---@field history_data table? For history mode: { commits, range, file_path, line_range }
 ---@field line_range table? For history line-range mode: { start_line, end_line }

--- a/plugin/codediff.lua
+++ b/plugin/codediff.lua
@@ -45,6 +45,20 @@ local function get_cached_rev_candidates(git_root)
   return candidates
 end
 
+-- Filter a list of flag candidates by prefix match against arg_lead
+local function complete_flags(candidates, arg_lead)
+  local filtered = {}
+  for _, flag in ipairs(candidates) do
+    if flag:find(arg_lead, 1, true) == 1 then
+      table.insert(filtered, flag)
+    end
+  end
+  if #filtered > 0 then
+    return filtered
+  end
+  return nil
+end
+
 -- Register user command with subcommand completion
 local function complete_codediff(arg_lead, cmd_line, _)
   local git = require('codediff.core.git')
@@ -69,22 +83,16 @@ local function complete_codediff(arg_lead, cmd_line, _)
     return vim.fn.getcompletion(arg_lead, "file")
   end
 
-  -- Special handling for history subcommand flags
-  if first_arg == "history" then
-    -- If arg_lead starts with -, complete flags
-    if arg_lead:match("^%-") then
-      local flag_candidates = { "--reverse", "-r", "--base", "-b" }
-      local filtered = {}
-      for _, flag in ipairs(flag_candidates) do
-        if flag:find(arg_lead, 1, true) == 1 then
-          table.insert(filtered, flag)
-        end
-      end
-      if #filtered > 0 then
-        return filtered
-      end
+  -- Flag completion for subcommands
+  if arg_lead:match("^%-") then
+    if first_arg == "history" then
+      local result = complete_flags({ "--reverse", "-r", "--base", "-b", "--inline", "--side-by-side" }, arg_lead)
+      if result then return result end
     end
-    -- Otherwise fall through to default completion (files, revisions)
+
+    -- Layout flags available for all subcommands
+    local result = complete_flags({ "--inline", "--side-by-side" }, arg_lead)
+    if result then return result end
   end
 
   -- For revision arguments, suggest git refs filtered by arg_lead


### PR DESCRIPTION
## Why?

`:CodeDiff` currently determines the diff layout solely from
`config.options.diff.layout`. There's no way to override the layout
per-invocation, which is inconvenient when you mostly prefer one layout
but occasionally want the other.

## What?

- Pre-parse `--inline` and `--side-by-side` flags at the top of the
  command dispatcher, stripping them before subcommand routing
- Thread `layout` through all handler functions into `session_config.layout`
- Extend `get_layout()` to check `session_config.layout` before falling
  back to the global config setting
- Add tab-completion for both flags across all subcommands
- Normalize hyphenated flag keys in args parser (`--side-by-side` → `side_by_side`)
- Conflict/merge mode continues to always use side-by-side regardless of flags