### PR TITLE
fix: git difftool leftover buffer and last-tab quit issues

### DIFF
--- a/lua/codediff/commands.lua
+++ b/lua/codediff/commands.lua
@@ -115,6 +115,11 @@ local function handle_file_diff(file_a, file_b, global_opts)
   -- Determine filetype from first file
   local filetype = vim.filetype.match({ filename = file_a }) or ""
 
+  -- Snapshot state before creating diff tab (for argv cleanup below)
+  local prev_tab = vim.api.nvim_get_current_tabpage()
+  local prev_tab_bufs = vim.api.nvim_tabpage_list_wins(prev_tab)
+  local is_single_win_tab = #prev_tab_bufs == 1
+
   -- Create diff view (no pre-reading needed, :edit will load content)
   ---@type SessionConfig
   local session_config = {
@@ -127,6 +132,31 @@ local function handle_file_diff(file_a, file_b, global_opts)
     layout = global_opts.layout,
   }
   view.create(session_config, filetype)
+
+  -- Clean up leftover tab from command-line args (git difftool scenario).
+  -- When invoked as `nvim "$LOCAL" "$REMOTE" +"CodeDiff file ..."`, neovim
+  -- creates a tab with the first argv file. Now that the diff tab exists,
+  -- that original tab is redundant. Close it remotely (without switching to
+  -- it) and defer to avoid interfering with startup autocmds / persistence.
+  -- Guard: only trigger when argv files match the diff files (so running
+  -- `:CodeDiff file a b` from an existing session won't close unrelated tabs).
+  local argc = vim.fn.argc()
+  if argc == 2 and is_single_win_tab then
+    local argv0 = vim.fn.fnamemodify(vim.fn.argv(0), ":p")
+    local argv1 = vim.fn.fnamemodify(vim.fn.argv(1), ":p")
+    local abs_a = vim.fn.fnamemodify(file_a, ":p")
+    local abs_b = vim.fn.fnamemodify(file_b, ":p")
+    local argv_matches = (argv0 == abs_a and argv1 == abs_b) or (argv0 == abs_b and argv1 == abs_a)
+    if argv_matches then
+      vim.schedule(function()
+        if vim.api.nvim_tabpage_is_valid(prev_tab) and prev_tab ~= vim.api.nvim_get_current_tabpage() then
+          local tab_nr = vim.api.nvim_tabpage_get_number(prev_tab)
+          vim.cmd(tab_nr .. "tabclose")
+        end
+        pcall(vim.cmd, "%argdelete")
+      end)
+    end
+  end
 end
 
 local function handle_dir_diff(dir1, dir2, global_opts)
@@ -581,7 +611,12 @@ function M.vscode_diff(opts)
     if not lifecycle.confirm_close_with_unsaved(current_tab) then
       return -- User cancelled
     end
-    vim.cmd("tabclose")
+    if #vim.api.nvim_list_tabpages() == 1 then
+      lifecycle.cleanup_for_quit(current_tab)
+      vim.cmd("qall")
+    else
+      vim.cmd("tabclose")
+    end
     return
   end
 

--- a/lua/codediff/ui/lifecycle/cleanup.lua
+++ b/lua/codediff/ui/lifecycle/cleanup.lua
@@ -215,6 +215,51 @@ function M.cleanup(tabpage)
   cleanup_diff(tabpage)
 end
 
+-- Aggressive cleanup for quitting neovim from the last diff tab.
+-- Deletes ALL codediff-owned buffers (explorer, scratch placeholders, virtual,
+-- result) so session-persistence plugins don't save them.
+function M.cleanup_for_quit(tabpage)
+  tabpage = tabpage or vim.api.nvim_get_current_tabpage()
+  local active_diffs = session.get_active_diffs()
+  local diff = active_diffs[tabpage]
+
+  -- Collect all codediff-owned buffer numbers before cleanup_diff removes tracking
+  local bufs_to_delete = {}
+  if diff then
+    -- Explorer / history panel buffer
+    if diff.explorer and diff.explorer.bufnr then
+      bufs_to_delete[diff.explorer.bufnr] = true
+    end
+    -- Diff pane buffers (virtual AND scratch placeholders)
+    if diff.original_bufnr then
+      bufs_to_delete[diff.original_bufnr] = true
+    end
+    if diff.modified_bufnr then
+      bufs_to_delete[diff.modified_bufnr] = true
+    end
+    -- Conflict result buffer
+    if diff.result_bufnr then
+      bufs_to_delete[diff.result_bufnr] = true
+    end
+  end
+
+  -- Run normal cleanup first (LSP notifications, autocmds, state restore, etc.)
+  cleanup_diff(tabpage)
+
+  -- Now force-delete all collected buffers that aren't real files worth keeping
+  for bufnr, _ in pairs(bufs_to_delete) do
+    if vim.api.nvim_buf_is_valid(bufnr) then
+      local bt = vim.bo[bufnr].buftype
+      local name = vim.api.nvim_buf_get_name(bufnr)
+      -- Keep real, named, on-disk file buffers; delete everything else
+      local is_real_file = bt == "" and name ~= "" and vim.fn.filereadable(name) == 1
+      if not is_real_file then
+        pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+      end
+    end
+  end
+end
+
 -- Cleanup all active diffs (useful for plugin unload/reload)
 function M.cleanup_all()
   local active_diffs = session.get_active_diffs()

--- a/lua/codediff/ui/lifecycle/init.lua
+++ b/lua/codediff/ui/lifecycle/init.lua
@@ -23,6 +23,7 @@ M.create_session = session.create_session
 -- Delegate to cleanup module
 M.setup_autocmds = cleanup.setup_autocmds
 M.cleanup = cleanup.cleanup
+M.cleanup_for_quit = cleanup.cleanup_for_quit
 M.cleanup_all = cleanup.cleanup_all
 M.setup = cleanup.setup
 

--- a/lua/codediff/ui/view/keymaps.lua
+++ b/lua/codediff/ui/view/keymaps.lua
@@ -23,7 +23,14 @@ function M.setup_all_keymaps(tabpage, original_bufnr, modified_bufnr, is_explore
     if not lifecycle.confirm_close_with_unsaved(tabpage) then
       return -- User cancelled
     end
-    vim.cmd("tabclose")
+    if #vim.api.nvim_list_tabpages() == 1 then
+      -- Last tab: clean up diff session first so session-persistence plugins
+      -- don't save scratch/virtual buffers, then quit neovim entirely.
+      lifecycle.cleanup_for_quit(tabpage)
+      vim.cmd("qall")
+    else
+      vim.cmd("tabclose")
+    end
   end
 
   -- Helper: Toggle explorer visibility (explorer mode only)


### PR DESCRIPTION
## Summary

Fixes two issues when using CodeDiff as `git difftool`:

### 1. Leftover argv tab
When invoked as `nvim "$LOCAL" "$REMOTE" +"CodeDiff file ..."`, neovim creates a tab for the first argv file. CodeDiff then creates a second tab for the diff view, leaving the original tab behind.

**Fix**: Detect the difftool pattern (`argc==2` + argv files match diff files) and close the leftover tab remotely via `Ntabclose` (no tab switching, no autocmd side effects). Deferred via `vim.schedule` to avoid startup interference.

### 2. Last-tab quit (`q` key and toggle)
When the diff tab is the only tab, `tabclose` fails with "Cannot close last tab page". Using `qall` works but session-persistence plugins save scratch/virtual buffers.

**Fix**: New `cleanup_for_quit()` function that deletes all codediff-owned buffers (explorer, scratch placeholders, virtual revision buffers) before calling `qall`. Real on-disk file buffers are preserved. Applied in both `quit_diff()` keymap and `CodeDiff` toggle close.

### Changed files
- `lua/codediff/commands.lua` — argv tab cleanup + last-tab quit in toggle
- `lua/codediff/ui/view/keymaps.lua` — last-tab quit in `q` keymap
- `lua/codediff/ui/lifecycle/cleanup.lua` — new `cleanup_for_quit()`
- `lua/codediff/ui/lifecycle/init.lua` — expose `cleanup_for_quit`

### Testing
All existing plenary tests pass.