### PR TITLE
fix(render): handle nil changes when cycling tabs

### DIFF
--- a/lua/codediff/ui/core.lua
+++ b/lua/codediff/ui/core.lua
@@ -323,6 +323,7 @@ function M.render_diff(left_bufnr, right_bufnr, original_lines, modified_lines, 
   local last_orig_line = 1
   local last_mod_line = 1
 
+  if not lines_diff.changes then return end
   for _, mapping in ipairs(lines_diff.changes) do
     local orig_is_empty = (mapping.original.end_line <= mapping.original.start_line)
     local mod_is_empty = (mapping.modified.end_line <= mapping.modified.start_line)


### PR DESCRIPTION
# Setup:
 1. One or more untracked files in the repo. 
 2. A few tabs are open besides the CodeDiff exporer with the selected untracked file in diff. 
 3. Start moving through tabs with `gt` (`gT`) to cycle around and get back to the same tab.
 4. Observe an error: nil value passed down.

# What's changed:
This fix adds a defensive nil check before invoking the iterator.

# Potential implications:
Maybe not the right place to handle the error since on the first cycling through tabs the untracked file has all of its entirety in the `lines_diff.changes` table, and also renders momentarily.