### PR TITLE
fix(test): remove duplicate on_file_select call causing flaky CI

### DIFF
--- a/tests/ui/explorer/hunk_operations_spec.lua
+++ b/tests/ui/explorer/hunk_operations_spec.lua
@@ -338,13 +338,10 @@ describe("Hunk operations (side-by-side)", function()
     local tabpage, session, explorer = open_codediff_and_wait(repo)
     local lifecycle = require("codediff.ui.lifecycle")
 
-    -- Select the file in the staged group
-    explorer.on_file_select({
-      path = "file1.txt",
-      status = "M",
-      git_root = repo.dir,
-      group = "staged",
-    })
+    -- The explorer auto-selects file1.txt in the "staged" group because
+    -- all changes are staged and there are no unstaged files.  We just
+    -- wait for that async selection to finish rather than issuing a
+    -- duplicate on_file_select call that would race with the auto-select.
 
     -- Wait for staged view (modified_revision == ":0") and 2 hunks
     local staged_ready = vim.wait(8000, function()


### PR DESCRIPTION
## Summary

Fixes flaky CI failure on Windows x64 and macOS ARM in `hunk_operations_spec.lua` ("unstage_hunk from staged view reduces hunk count").

## Root Cause

The test called `explorer.on_file_select()` for the staged file immediately after `open_codediff_and_wait()`, but the explorer already auto-selects that same file on startup when all changes are staged. The two concurrent async git operations raced — on slower CI runners the callbacks would interfere, leaving `modified_revision` unset and failing the assertion.

## Changes

- Removed the redundant `on_file_select()` call in the test
- Let the explorer's built-in auto-selection handle the initial file selection
- All tests pass locally (0 failures across full suite)

## Testing

- Full test suite passes locally
- The specific `unstage_hunk from staged view reduces hunk count` test passes reliably