### PR TITLE
fix(keymaps): guard nil changes in find_hunk_at_cursor

### DIFF
--- a/lua/codediff/ui/view/keymaps.lua
+++ b/lua/codediff/ui/view/keymaps.lua
@@ -70,7 +70,7 @@ function M.setup_all_keymaps(tabpage, original_bufnr, modified_bufnr, is_explore
       return nil, nil
     end
     local diff_result = session.stored_diff_result
-    if #diff_result.changes == 0 then
+    if not diff_result.changes or #diff_result.changes == 0 then
       return nil, nil
     end
 


### PR DESCRIPTION
## Summary

Fixes `E5108: Lua: attempt to get length of field 'changes' (a nil value)` crash in `find_hunk_at_cursor()` when invoking hunk operations (stage/unstage/discard) while `stored_diff_result.changes` is nil.

## Root Cause

`find_hunk_at_cursor()` checked `#diff_result.changes == 0` without first verifying `.changes` is non-nil. This crashes when `stored_diff_result` exists but `.changes` is nil — the same class of bug fixed in PR #313 for `render_diff()`.

## Changes

- Added nil guard: `if not diff_result.changes or #diff_result.changes == 0 then`

## Testing

- Same pattern already validated in PR #313
- Single-line defensive fix with no behavioral change when `.changes` is present