### PR TITLE
feat(explorer): add highlight for group headers

### DIFF
--- a/lua/codediff/ui/explorer/nodes.lua
+++ b/lua/codediff/ui/explorer/nodes.lua
@@ -281,8 +281,8 @@ function M.prepare_node(node, max_width, selected_path, selected_group)
 
   if data.type == "group" then
     -- Group header
-    line:append(" ", "Directory")
-    line:append(node.text, "Directory")
+    line:append(" ", "CodeDiffExplorerTreeGroup")
+    line:append(node.text, "CodeDiffExplorerTreeGroup")
   elseif data.type == "directory" then
     -- Directory node (tree view mode) - with indent markers
     local indent = build_indent_markers(data.indent_state)

--- a/lua/codediff/ui/highlights.lua
+++ b/lua/codediff/ui/highlights.lua
@@ -169,6 +169,11 @@ function M.setup()
     default = true,
   })
 
+  vim.api.nvim_set_hl(0, "CodeDiffExplorerTreeGroup", {
+    link = "Exception",
+    default = true,
+  })
+
   -- Explorer git status highlights (customizable, like diffview.nvim)
   vim.api.nvim_set_hl(0, "CodeDiffStatusAdded", { link = "DiagnosticOk", default = true })
   vim.api.nvim_set_hl(0, "CodeDiffStatusModified", { link = "DiagnosticWarn", default = true })


### PR DESCRIPTION
Add a dedicated highlight group CodeDiffExplorerTreeGroup (linked to Exception) and update explorer nodes to use it for group headers instead of the generic Directory highlight to improve visual grouping.

<img width="384" height="582" alt="image" src="https://github.com/user-attachments/assets/021d418d-e864-48e5-8aeb-1ab897939d4d" />

This should fix #318