### PR TITLE
fix(ui): remove possible noise caused by user's configuration

### DIFF
--- a/lua/codediff/ui/view/side_by_side.lua
+++ b/lua/codediff/ui/view/side_by_side.lua
@@ -124,6 +124,7 @@ function M.create(session_config, filetype, on_ready)
   local win_opts = {
     cursorline = true,
     wrap = false,
+    list = false,
   }
 
   for opt, val in pairs(win_opts) do


### PR DESCRIPTION
Hello! I really like your plugin, thanks for creating and maintaining this project.
This pr disables displaying of listchars, for example in my config i have this
```lua
listchars = { trail = "•" }
```
and it causes to render those symbols in explorer panel (after M letter):
<img width="305" height="178" alt="image" src="https://github.com/user-attachments/assets/bb2986f4-d187-4d84-b058-5c225324c5db" />
after applying this PR:
<img width="306" height="167" alt="image" src="https://github.com/user-attachments/assets/3a23b275-b3ce-43c6-a701-bd4da26a5b8f" />
