### PR TITLE
feat(explorer): support position = "right"

### DIFF
--- a/lua/codediff/config.lua
+++ b/lua/codediff/config.lua
@@ -48,7 +48,7 @@ M.defaults = {
 
   -- Explorer panel configuration
   explorer = {
-    position = "left", -- "left" or "bottom"
+    position = "left", -- "left", "right", or "bottom"
     width = 40, -- Width when position is "left" (columns)
     height = 15, -- Height when position is "bottom" (lines)
     view_mode = "list", -- "list" (flat file list) or "tree" (directory tree)
@@ -72,7 +72,7 @@ M.defaults = {
 
   -- History panel configuration (for :CodeDiff history)
   history = {
-    position = "bottom", -- "left" or "bottom" (default: bottom)
+    position = "bottom", -- "left", "right", or "bottom" (default: bottom)
     width = 40, -- Width when position is "left" (columns)
     height = 15, -- Height when position is "bottom" (lines)
     initial_focus = "history", -- Initial focus: "history", "original", or "modified"

--- a/lua/codediff/ui/layout.lua
+++ b/lua/codediff/ui/layout.lua
@@ -35,7 +35,7 @@ function M.arrange(tabpage)
 
   -- Step 1: Pin panel size (fixed element)
   if panel_visible then
-    if panel_position == "left" then
+    if panel_position == "left" or panel_position == "right" then
       vim.api.nvim_win_set_width(panel_win, panel_config.width)
     else
       vim.api.nvim_win_set_height(panel_win, panel_config.height)
@@ -51,7 +51,7 @@ function M.arrange(tabpage)
     local sole_win = orig_valid and original_win or (mod_valid and modified_win or nil)
     if sole_win then
       if panel_visible then
-        if panel_position == "left" then
+        if panel_position == "left" or panel_position == "right" then
           vim.api.nvim_win_set_width(panel_win, panel_config.width)
           -- Explicitly set diff window to fill remainder
           local remainder = vim.o.columns - panel_config.width - 1
@@ -117,7 +117,7 @@ function M.arrange(tabpage)
 
   -- Step 5: Re-pin panel size (undo disturbance from step 4)
   if panel_visible then
-    if panel_position == "left" then
+    if panel_position == "left" or panel_position == "right" then
       vim.api.nvim_win_set_width(panel_win, panel_config.width)
     else
       vim.api.nvim_win_set_height(panel_win, panel_config.height)


### PR DESCRIPTION
Hey! I wanted to put my explorer panel on the right side. The config docs say "left" or "bottom", but I noticed `split.lua` already handles `"right"` in its position map and does the right width/height logic for it, so I figured it was worth a shot.

It mostly works! The panel opens on the right side correctly. The only issue is in `layout.lua`: `arrange()` checks `panel_position == "left"` before calling `set_width`, so `"right"` falls through to `set_height` instead. This breaks the layout pretty badly with `cmdheight=0` (noice.nvim in my case).

The fix just adds `"right"` to the three width checks in `arrange()`, matching what `split.lua` already does. I also updated the config comments to document that `"right"` is a valid option for both explorer and history panels.

Happy to adjust anything if you'd prefer a different approach. Thanks for the great plugin!

(AI tooling helped me trace the layout issue. Fix verified manually.)