### PR TITLE
feat(explorer): support position = "right"

### DIFF
--- a/lua/codediff/config.lua
+++ b/lua/codediff/config.lua
@@ -48,7 +48,7 @@ M.defaults = {
 
   -- Explorer panel configuration
   explorer = {
-    position = "left", -- "left" or "bottom"
+    position = "left", -- "left", "right", or "bottom"
     width = 40, -- Width when position is "left" (columns)
     height = 15, -- Height when position is "bottom" (lines)
     view_mode = "list", -- "list" (flat file list) or "tree" (directory tree)
@@ -72,7 +72,7 @@ M.defaults = {
 
   -- History panel configuration (for :CodeDiff history)
   history = {
-    position = "bottom", -- "left" or "bottom" (default: bottom)
+    position = "bottom", -- "left", "right", or "bottom" (default: bottom)
     width = 40, -- Width when position is "left" (columns)
     height = 15, -- Height when position is "bottom" (lines)
     initial_focus = "history", -- Initial focus: "history", "original", or "modified"

--- a/lua/codediff/ui/layout.lua
+++ b/lua/codediff/ui/layout.lua
@@ -35,7 +35,7 @@ function M.arrange(tabpage)
 
   -- Step 1: Pin panel size (fixed element)
   if panel_visible then
-    if panel_position == "left" then
+    if panel_position == "left" or panel_position == "right" then
       vim.api.nvim_win_set_width(panel_win, panel_config.width)
     else
       vim.api.nvim_win_set_height(panel_win, panel_config.height)
@@ -51,7 +51,7 @@ function M.arrange(tabpage)
     local sole_win = orig_valid and original_win or (mod_valid and modified_win or nil)
     if sole_win then
       if panel_visible then
-        if panel_position == "left" then
+        if panel_position == "left" or panel_position == "right" then
           vim.api.nvim_win_set_width(panel_win, panel_config.width)
           -- Explicitly set diff window to fill remainder
           local remainder = vim.o.columns - panel_config.width - 1
@@ -117,7 +117,7 @@ function M.arrange(tabpage)
 
   -- Step 5: Re-pin panel size (undo disturbance from step 4)
   if panel_visible then
-    if panel_position == "left" then
+    if panel_position == "left" or panel_position == "right" then
       vim.api.nvim_win_set_width(panel_win, panel_config.width)
     else
       vim.api.nvim_win_set_height(panel_win, panel_config.height)


### PR DESCRIPTION
Would love to be able to put the explorer panel on the right side. I poked around and it looks like `split.lua` already supports `"right"` in its position map, so adding it was pretty straightforward.

The main change is in `layout.lua`: `arrange()` assumed the panel was either `"left"` (vertical) or `"bottom"` (horizontal), so `"right"` fell through to the wrong sizing path. This adds `"right"` to the width checks at the three sites in `arrange()`, and updates the config comments for both explorer and history panels.

Without the fix, `"right"` technically "works" (the panel appears on the right) but the layout breaks if you're running `cmdheight=0`.

(AI tooling helped with debugging. Fix verified manually.)