### PR TITLE
fix: defer TabClosed cleanup to prevent window-switching error

### DIFF
--- a/lua/codediff/ui/lifecycle/cleanup.lua
+++ b/lua/codediff/ui/lifecycle/cleanup.lua
@@ -176,19 +176,21 @@ function M.setup_autocmds()
   vim.api.nvim_create_autocmd("TabClosed", {
     group = augroup,
     callback = function()
-      -- TabClosed doesn't give us the tab number, so we need to scan
-      -- Remove any diffs for tabs that no longer exist
-      local valid_tabs = {}
-      for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
-        valid_tabs[tabpage] = true
-      end
-
-      local active_diffs = session.get_active_diffs()
-      for tabpage, _ in pairs(active_diffs) do
-        if not valid_tabs[tabpage] then
-          cleanup_diff(tabpage)
+      vim.schedule(function()
+        -- TabClosed doesn't give us the tab number, so we need to scan
+        -- Remove any diffs for tabs that no longer exist
+        local valid_tabs = {}
+        for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
+          valid_tabs[tabpage] = true
         end
-      end
+
+        local active_diffs = session.get_active_diffs()
+        for tabpage, _ in pairs(active_diffs) do
+          if not valid_tabs[tabpage] then
+            cleanup_diff(tabpage)
+          end
+        end
+      end)
     end,
   })
 


### PR DESCRIPTION
Hi there - very nice plugin!

I hit this error when running `open_in_prev_tab` with `close_on_open_in_prev_tab = true`

```
E5108:%20Error%20executing%20lua%3A%20vim/_editor.lua:0:%20nvim_exec2()%5B1%5D..TabClosed%20Autocommands%20for%20%22*%22:%20Vim(append):Error%20executing%20lua%20callback:%20...zy/codediff.nvim/lua/codediff/ui/view/welcome_window.lua:35:%20Problem%20w%0Ahile%20switching%20windows%0Astack%20traceback:%0A%20%20%20%20%20%20%20%20%5BC%5D:%20in%20function%20'__newindex'%0A%20%20%20%20%20%20%20%20...zy/codediff.nvim/lua/codediff/ui/view/welcome_window.lua:35:%20in%20function%20'apply_opts'%0A%20%20%20%20%20%20%20%20...zy/codediff.nvim/lua/codediff/ui/view/welcome_window.lua:90:%20in%20function%20'apply_normal'%0A%20%20%20%20%20%20%20%20...lazy/codediff.nvim/lua/codediff/ui/lifecycle/cleanup.lua:100:%20in%20function%20'cleanup_diff'%0A%20%20%20%20%20%20%20%20...lazy/codediff.nvim/lua/codediff/ui/lifecycle/cleanup.lua:189:%20in%20function%20%3C...lazy/codediff.nvim/lua/codediff/ui/lifecycle/cleanup.lua:178%3E%0A%20%20%20%20%20%20%20%20%5BC%5D:%20in%20function%20'nvim_exec2'%0A%20%20%20%20%20%20%20%20vim/_editor.lua:%20in%20function%20'cmd'%0A%20%20%20%20%20%20%20%20...nvim/lazy/codediff.nvim/lua/codediff/ui/view/keymaps.lua:352:%20in%20function%20%3C...nvim/lazy/codediff.nvim/lua/codediff/ui/view/keymaps.lua:263%3E%0Astack%20traceback:%0A%20%20%20%20%20%20%20%20%5BC%5D:%20in%20function%20'nvim_exec2'%0A%20%20%20%20%20%20%20%20vim/_editor.lua:%20in%20function%20'cmd'%0A%20%20%20%20%20%20%20%20...nvim/lazy/codediff.nvim/lua/codediff/ui/view/keymaps.lua:352:%20in%20function%20%3C...nvim/lazy/codediff.nvim/lua/codediff/ui/view/keymaps.lua:263%3E%0APress%20ENTER%20or%20type%20command%20to%20continue
```

And [amp](https://ampcode.com/) fixed it with this diff. It solved the problem for but I'm new to nvim/lua so I have absolutely no idea if it's a sensible fix 😅 

But opening a PR in case it helps others!

Amp explained it like this:

### Problem

Using `open_in_prev_tab` with `close_on_open_in_prev_tab = true` triggers
E5108: "Problem while switching windows".

The `TabClosed` autocmd runs `cleanup_diff` synchronously, which eventually
calls `vim.wo[winid][name] = value` in `welcome_window.apply_opts`. Setting
window-local options requires Neovim to switch windows internally, which is
forbidden during a `TabClosed` event.

### Fix

Wrap the `TabClosed` callback body in `vim.schedule()` to defer cleanup
until after the event loop settles. This matches the pattern already used
by the `WinClosed` handler in the same file.