### PR TITLE
fix(ui): add missing keymaps to g? help menu

### DIFF
--- a/lua/codediff/ui/keymap_help.lua
+++ b/lua/codediff/ui/keymap_help.lua
@@ -61,6 +61,10 @@ local function build_sections(keymaps, is_explorer, is_history, is_conflict)
     table.insert(view_items, { km.unstage_hunk, "Unstage hunk under cursor" })
     table.insert(view_items, { km.discard_hunk, "Discard hunk under cursor" })
   end
+  table.insert(view_items, { km.toggle_layout, "Toggle inline/side-by-side layout" })
+  if km.align_move then
+    table.insert(view_items, { km.align_move, "Align moved code block" })
+  end
   table.insert(view_items, { km.hunk_textobject, "Hunk textobject (visual/operator)" })
   table.insert(view_items, { km.show_help, "Toggle this help" })
   table.insert(sections, section("VIEW", view_items))


### PR DESCRIPTION
## Why?

The `toggle_layout` (`t`) and `align_move` (`gm`) keymaps were bound in the diff view but not displayed in the `g?` keymap help floating window.

## What?

- Add `toggle_layout` and `align_move` entries to the VIEW section of the help menu
- `align_move` is conditionally shown only when configured