### PR TITLE
fix(ui): set winfixwidth and winfixheight for explorer window

### DIFF
--- a/lua/codediff/ui/explorer/render.lua
+++ b/lua/codediff/ui/explorer/render.lua
@@ -88,6 +88,8 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
       wrap = false,
       signcolumn = "no",
       foldcolumn = "0",
+      winfixwidth = true,
+      winfixheight = true,
     },
   })
 


### PR DESCRIPTION
Set `winfixwidth` and `winfixheight` on the explorer window so it is excluded from `<C-w>=` equalization.