### PR TITLE
fix: refresh diff view after discard_hunk

### DIFF
--- a/lua/codediff/ui/view/keymaps.lua
+++ b/lua/codediff/ui/view/keymaps.lua
@@ -544,6 +544,13 @@ function M.setup_all_keymaps(tabpage, original_bufnr, modified_bufnr, is_explore
         vim.notify("Failed to discard hunk: " .. err, vim.log.levels.ERROR)
         return
       end
+      -- Reload modified buffer from disk (working tree file changed)
+      if vim.api.nvim_buf_is_valid(discard_mod_buf) then
+        vim.api.nvim_buf_call(discard_mod_buf, function()
+          vim.cmd("checktime")
+        end)
+        auto_refresh.trigger(discard_mod_buf)
+      end
       vim.notify(string.format("Discarded hunk %d", hunk_idx), vim.log.levels.INFO)
     end)
   end

--- a/tests/ui/explorer/hunk_operations_spec.lua
+++ b/tests/ui/explorer/hunk_operations_spec.lua
@@ -380,7 +380,7 @@ describe("Hunk operations (side-by-side)", function()
   -- --------------------------------------------------------------------------
   -- Test 4: discard_hunk reverts working tree and updates diff
   -- --------------------------------------------------------------------------
-  it("discard_hunk reverts working tree file", function()
+  it("discard_hunk reverts working tree file and refreshes diff", function()
     repo = create_two_hunk_repo()
     local tabpage, session, explorer = open_codediff_and_wait(repo)
     local lifecycle = require("codediff.ui.lifecycle")
@@ -408,8 +408,9 @@ describe("Hunk operations (side-by-side)", function()
     -- Restore original vim.fn.confirm
     vim.fn.confirm = original_confirm
 
-    -- Wait for the async git operation to complete
-    vim.wait(2000, function() return false end, 100)
+    -- Wait for the async git operation and diff refresh to complete
+    local has_1 = wait_for_hunks(tabpage, 1, 5000)
+    assert.is_true(has_1, "Diff should refresh to show 1 hunk after discarding hunk 1")
 
     -- Verify file content on disk: line 1 should be reverted to original
     local disk_lines = vim.fn.readfile(repo.path("file1.txt"))


### PR DESCRIPTION
discard_hunk reverse-applies a patch on disk but didn’t reload the open buffer, leaving stale hunks in the diff view.

After a successful discard, run checktime to reload the buffer and trigger auto_refresh to recompute the diff.