### PR TITLE
fix(explorer): restore Directory color for group headers

### DIFF
--- a/lua/codediff/ui/highlights.lua
+++ b/lua/codediff/ui/highlights.lua
@@ -170,7 +170,7 @@ function M.setup()
   })
 
   vim.api.nvim_set_hl(0, "CodeDiffExplorerTreeGroup", {
-    link = "Exception",
+    link = "Directory",
     default = true,
   })
 


### PR DESCRIPTION
## Summary

PR #319 introduced a new `CodeDiffExplorerTreeGroup` highlight group for explorer group headers (good change), but linked it to `Exception` by default. On most colorschemes `Exception` renders as red/orange and visually reads as an error state, which is jarring for a neutral UI grouping element.

## Changes

- Change the default link of `CodeDiffExplorerTreeGroup` from `Exception` to `Directory` in `lua/codediff/ui/highlights.lua`.

## Benefits

- Restores the pre-#319 visual appearance by default — no surprise color change for users on upgrade.
- Keeps the dedicated highlight group introduced in #319, so users who *want* group headers to look different from directories can still opt in via:
  ```lua
  vim.api.nvim_set_hl(0, "CodeDiffExplorerTreeGroup", { link = "Title" })
  ```

## Testing

Manual: Loaded the explorer; group headers render in the Directory color (matches pre-#319 behavior). Override via `nvim_set_hl` still works because the highlight is registered with `default = true`.