### PR TITLE
Fix standalone working tree diffs outside repo cwd

### DIFF
--- a/lua/codediff/ui/view/helpers.lua
+++ b/lua/codediff/ui/view/helpers.lua
@@ -20,6 +20,17 @@ local function bufnr_exact(name)
   return -1
 end
 
+local function is_absolute_path(path)
+  return path:match("^/") or path:match("^%a:[/\\]") or path:match("^\\\\")
+end
+
+local function real_file_target(git_root, path)
+  if git_root and path ~= "" and not is_absolute_path(path) then
+    return git_root .. "/" .. path
+  end
+  return path
+end
+
 -- Prepare buffer information for loading
 -- Returns: { bufnr = number?, target = string?, needs_edit = boolean }
 -- - If buffer already exists: { bufnr = 123, target = nil, needs_edit = false }
@@ -53,7 +64,8 @@ function M.prepare_buffer(is_virtual, git_root, revision, path)
     end
   else
     -- Real file: use exact match for buffer lookup
-    local existing_buf = bufnr_exact(path)
+    local target = real_file_target(git_root, path)
+    local existing_buf = bufnr_exact(target)
     if existing_buf ~= -1 then
       -- Buffer already exists, reuse it
       return {
@@ -65,7 +77,7 @@ function M.prepare_buffer(is_virtual, git_root, revision, path)
       -- Buffer doesn't exist, need to :edit it
       return {
         bufnr = nil,
-        target = path,
+        target = target,
         needs_edit = true,
       }
     end


### PR DESCRIPTION
This is Codex opening this on behalf of Michael Fortunato.

This replaces #373, which GitHub closed after the fork branch was force-pushed while narrowing the patch.

## Summary

Michael noticed two `codediff.nvim` flows behaved differently:

- Bare `:CodeDiff` consistently showed the working-tree diff.
- `:CodeDiff file HEAD --inline` sometimes opened a blank modified buffer instead of the file content.

Both commands use codediff, but they do not take the same code path. Bare `:CodeDiff` uses explorer/review mode. `:CodeDiff file HEAD --inline` uses standalone inline file mode.

## Root Cause

The bug is cwd/path handling when a git-relative real file path is loaded into a buffer.

Standalone file mode stores git paths as repo-relative paths, which is the right representation for revision-backed buffers and git-object lookups. But for the working-tree side, that same path eventually becomes the target for `:edit`.

Before this PR, the real-file loading helper looked up and edited the path exactly as provided:

```lua
local existing_buf = bufnr_exact(path)
-- later
target = path
```

If Neovim's cwd is not the git root, a repo-relative path such as `sub/file.txt` resolves against the wrong directory, so Neovim creates or opens a blank buffer at the wrong path.

Explorer mode does not hit this because it already passes an absolute working-tree path for real files, equivalent to:

```lua
modified_path = git_root .. "/" .. file_path
```

That explains why bare `:CodeDiff` worked while `:CodeDiff file HEAD --inline` could fail, even though both ultimately use the same diff engine.

## Fix

The fix is in the shared real-file buffer loading helper, not in command/session state.

When `prepare_buffer()` is loading a real file and has a `git_root`, it now resolves a non-absolute path to an absolute edit target:

```lua
local target = real_file_target(git_root, path)
```

The session path itself stays repo-relative. That keeps the existing path contract intact for git-object paths, virtual URLs, lifecycle state, layout toggles, and any downstream code that expects git paths to remain repo-relative.

## Verification

I reproduced the behavior in a throwaway git repo:

- `:CodeDiff file HEAD --inline` with cwd outside the repo opened the wrong path and showed a blank modified buffer before the fix.
- With this patch, the command loads the real working-tree file while `session.modified_path` remains repo-relative, e.g. `sub/file.txt`.
- Bare `:CodeDiff` continues to work because absolute explorer paths are left unchanged.

I kept the PR limited to production code only, with no test-suite changes.

## Testing

- Manual headless repro for `:CodeDiff file HEAD --inline` from outside the git root
- `make lint`
- `make test-lua`