### PR TITLE
fix(ui): fix buffer lookup for `CodeDiff file HEAD`

### DIFF
--- a/lua/codediff/ui/view/helpers.lua
+++ b/lua/codediff/ui/view/helpers.lua
@@ -53,7 +53,7 @@ function M.prepare_buffer(is_virtual, git_root, revision, path)
     end
   else
     -- Real file: use exact match for buffer lookup
-    local existing_buf = bufnr_exact(path)
+    local existing_buf = bufnr_exact(vim.fs.joinpath(git_root, path))
     if existing_buf ~= -1 then
       -- Buffer already exists, reuse it
       return {


### PR DESCRIPTION
### Fix `CodeDiff file HEAD` buffer lookup 

`bufnr_exact()` compares `nvim_buf_get_name(buf)` (absolute path) with the input `path` (relative to git root), so the match always fails and `existing_buf` stays `-1`.

When nvim’s working directory is the Git repository root, the file opens correctly. But when nvim is not in the Git root, it tries to open a non-existent file.

e.g. diffing `nvim/init.lua` from `~/dotfiles/nvim` produces:

`~/dotfiles/nvim/nvim/init.lua`
<img width="1552" height="982" alt="Screenshot 2026-05-10 at 00 04 46" src="https://github.com/user-attachments/assets/4e0f4c03-0afe-42df-bc04-d6db12a79fee" />

Fix: join the file path with `git_root` before calling `bufnr_exact()`, so buffer lookup uses the correct absolute path.
