### PR TITLE
fix(virtual_file): suppress FileType event for added/deleted-file buffers

### DIFF
--- a/lua/codediff/core/virtual_file.lua
+++ b/lua/codediff/core/virtual_file.lua
@@ -26,7 +26,10 @@ local function load_virtual_buffer_content(buf, git_root, commit, filepath)
         api.nvim_buf_set_lines(buf, 0, -1, false, { "" })
         vim.bo[buf].modifiable = false
         vim.bo[buf].readonly = true
-        vim.bo[buf].filetype = ""
+        -- Clear filetype without firing FileType autocmd (see issue #323; matches setup_buffer below).
+        api.nvim_buf_call(buf, function()
+          vim.cmd("noautocmd setlocal filetype=")
+        end)
         vim.diagnostic.enable(false, { bufnr = buf })
 
         -- Fire loaded event so diff rendering proceeds

--- a/tests/core/virtual_file_lsp_spec.lua
+++ b/tests/core/virtual_file_lsp_spec.lua
@@ -99,4 +99,66 @@ describe("Virtual buffer LSP prevention", function()
     pcall(vim.api.nvim_buf_delete, buf, { force = true })
     repo.cleanup()
   end)
+
+  it("does not fire FileType for added/deleted files (regression: #323)", function()
+    -- Regression for issue #323: when opening a diff for a file that does not
+    -- exist at the requested revision (added or deleted), virtual_file used to
+    -- set `vim.bo[buf].filetype = ""` directly. That assignment fires a
+    -- FileType autocmd with an empty filetype, which crashes user/plugin code
+    -- that keys memoize caches on the filetype string. The fix suppresses the
+    -- event via `noautocmd setlocal filetype=` (matching the populated branch).
+    virtual_file.setup()
+    local repo = h.create_temp_git_repo()
+    local f = io.open(repo.dir .. "/kept.lua", "w")
+    f:write("kept\n")
+    f:close()
+    repo.git("add .")
+    repo.git('commit -m "initial"')
+
+    -- Listen for FileType events on codediff:// buffers. Any event with an
+    -- empty filetype is the regression we are guarding against.
+    local empty_ft_events = {}
+    local autocmd_id = vim.api.nvim_create_autocmd("FileType", {
+      callback = function(args)
+        local name = vim.api.nvim_buf_get_name(args.buf)
+        if name:match("^codediff://") then
+          table.insert(empty_ft_events, {
+            buf = args.buf,
+            ft = vim.bo[args.buf].filetype,
+            name = name,
+          })
+        end
+      end,
+    })
+
+    -- Open a codediff:// URL for a file that does NOT exist at HEAD.
+    -- This is the path through virtual_file.load_virtual_buffer_content's
+    -- error branch where filetype gets cleared.
+    local url = "codediff:///" .. repo.dir .. "///HEAD/does_not_exist.lua"
+    vim.cmd("edit " .. vim.fn.fnameescape(url))
+    local buf = vim.api.nvim_get_current_buf()
+
+    -- Wait for async load_virtual_buffer_content to complete; we know it
+    -- completed when the "missing file" placeholder is in place.
+    vim.wait(2000, function()
+      if not vim.api.nvim_buf_is_valid(buf) then return false end
+      return vim.bo[buf].modifiable == false
+    end)
+
+    -- No FileType event should have fired on the codediff:// buffer with an
+    -- empty filetype (that's the crash trigger).
+    local empty_ones = vim.tbl_filter(function(e) return e.ft == "" end, empty_ft_events)
+    assert.are.equal(0, #empty_ones,
+      "FileType autocmd fired with empty filetype on virtual buffer (issue #323): " ..
+      vim.inspect(empty_ones))
+
+    -- The filetype is still empty (still preventing LSP attachment), the event
+    -- just wasn't broadcast.
+    assert.are.equal("", vim.bo[buf].filetype,
+      "filetype should still be empty on the missing-file virtual buffer")
+
+    vim.api.nvim_del_autocmd(autocmd_id)
+    pcall(vim.api.nvim_buf_delete, buf, { force = true })
+    repo.cleanup()
+  end)
 end)


### PR DESCRIPTION
## What

Fixes the crash reported in #323 when entering the diff view for an added or deleted file (one side of the diff has no content in the requested revision).

## Why

`virtual_file.load_virtual_buffer_content` clears the buffer's filetype for the "missing side" buffer so LSP plugins don't attach to the `codediff://` URI. The fast path (`setup_buffer`, line 168) does this correctly via `noautocmd setlocal filetype=`. The async error path (line 29, for missing-revision files) did the same thing via `vim.bo[buf].filetype = ""` — which **does fire the FileType autocmd** with an empty value.

User and plugin code that key memoize caches on the filetype string (e.g. treesitter helpers, LazyVim FileType callbacks, `vim.func._memoize` consumers) then crash:

```
invalid value (nil) at index 1 in table for 'concat'
  /Users/.../config/autocmds.lua:52
  vim/func/_memoize.lua:75
  codediff/core/virtual_file.lua:29
```

This is the exact scenario in #323.

## How

Switch line 29 to the same `noautocmd setlocal filetype=` pattern already used at line 168, wrapped in `nvim_buf_call` so it targets the right buffer from inside the async `vim.schedule` callback (the user could have moved focus between the git fetch starting and finishing).

```diff
- vim.bo[buf].filetype = ""
+ api.nvim_buf_call(buf, function()
+   vim.cmd("noautocmd setlocal filetype=")
+ end)
```

Behavior is unchanged for LSP isolation: filetype is still empty after the call; only the `FileType` event is suppressed.

I verified the equivalence empirically — `vim.api.nvim_set_option_value("filetype", "", { buf = buf })` was tempting as a simpler form but also fires `FileType`; only `noautocmd setlocal filetype=` actually suppresses the event.

## Test

Added a regression test in `tests/core/virtual_file_lsp_spec.lua` (per the convention of extending existing specs rather than creating new files). It opens a `codediff://` URL for a path that does not exist at HEAD and asserts:
- Zero `FileType` events fired on the codediff:// buffer
- `filetype` is still `""` afterwards (LSP isolation preserved)

Standalone-verified the assertions pass against this fix (plenary segfaults on local nvim-0.12-nightly — tracked separately in #367 — but CI uses stable nvim).

Closes #323