### PR TITLE
fix(layout): re-pin explorer/history panel width on VimResized

### DIFF
--- a/lua/codediff/ui/lifecycle/cleanup.lua
+++ b/lua/codediff/ui/lifecycle/cleanup.lua
@@ -212,6 +212,22 @@ function M.setup_autocmds()
       end
     end,
   })
+
+  -- Re-pin panel widths on terminal/tmux resize for every active diff session
+  -- (see issue #346). VimResized is editor-global, so one autocmd handles all
+  -- tabs; layout.arrange() is a no-op for tabs without a session.
+  vim.api.nvim_create_autocmd("VimResized", {
+    group = augroup,
+    callback = function()
+      local ok_l, layout = pcall(require, "codediff.ui.layout")
+      if not ok_l then
+        return
+      end
+      for tabpage, _ in pairs(session.get_active_diffs()) do
+        pcall(layout.arrange, tabpage)
+      end
+    end,
+  })
 end
 
 -- Manual cleanup function (can be called explicitly)

--- a/tests/ui/layout_spec.lua
+++ b/tests/ui/layout_spec.lua
@@ -1191,4 +1191,50 @@ describe("Layout Manager", function()
 
     cleanup_mock_session(tabpage)
   end)
+
+  -- Regression test: #346 — panel width should be re-applied on VimResized
+  it("re-pins panel width on VimResized (regression: #346)", function()
+    local panel_width = 28
+    local panel = create_panel_split("left", panel_width)
+    vim.cmd("vsplit")
+    local orig_win = vim.api.nvim_get_current_win()
+    vim.cmd("vsplit")
+    local mod_win = vim.api.nvim_get_current_win()
+    local orig_buf = vim.api.nvim_create_buf(false, true)
+    local mod_buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_win_set_buf(orig_win, orig_buf)
+    vim.api.nvim_win_set_buf(mod_win, mod_buf)
+
+    local tabpage = vim.api.nvim_get_current_tabpage()
+    local session_mod = require("codediff.ui.lifecycle.session")
+    config.options.explorer = config.options.explorer or {}
+    config.options.explorer.width = panel_width
+    session_mod.create_session(
+      tabpage, "explorer", "/tmp", "", "", nil, nil,
+      orig_buf, mod_buf, orig_win, mod_win, {}, nil
+    )
+    local accessors = require("codediff.ui.lifecycle.accessors")
+    accessors.set_explorer(tabpage, panel)
+
+    -- The VimResized autocmd is installed by lifecycle.setup() (once-guarded by
+    -- view.create()). This test creates the session directly, bypassing view.create(),
+    -- so we install the autocmds explicitly to exercise the resize path.
+    require("codediff.ui.lifecycle.cleanup").setup_autocmds()
+
+    -- Pin the configured width first, then sabotage it (simulating what a real
+    -- terminal resize does to the layout) and confirm VimResized re-pins it.
+    layout.arrange(tabpage)
+    local initial = vim.api.nvim_win_get_width(panel.winid)
+    assert_width_near(panel_width, initial, "Initial panel width should match config:")
+
+    vim.api.nvim_win_set_width(panel.winid, 90) -- sabotage
+    vim.cmd("doautocmd VimResized")
+    vim.wait(50)
+
+    local restored = vim.api.nvim_win_get_width(panel.winid)
+    assert_width_near(panel_width, restored, "VimResized should re-pin panel width:")
+
+    cleanup_mock_session(tabpage)
+    pcall(panel.split.unmount, panel.split)
+  end)
 end)


### PR DESCRIPTION
## What

When the parent terminal (or tmux pane) is resized, the explorer / history panel widens beyond its configured `explorer.width` / `history.width`. Reproduces by opening `:CodeDiff` and then resizing the terminal or splitting a tmux pane.

Reporter's diagnosis was exactly right — `layout.arrange()` already pins the panel; it just wasn't being re-invoked on resize.

## How

Single editor-global `VimResized` autocmd registered alongside the existing `WinClosed` / `TabClosed` / `BufEnter` autocmds in `lifecycle/cleanup.lua:setup_autocmds()`. On each resize, iterates `session.get_active_diffs()` and calls `layout.arrange(tabpage)` for every active CodeDiff tab.

Chose `cleanup.lua` because that's where the other editor-global autocmds for codediff already live; matching that pattern keeps lifecycle autocmd registration in one file. (Tab-specific autocmds like `LspAttach` go in `session.lua`'s per-tab augroup instead.)

```lua
vim.api.nvim_create_autocmd("VimResized", {
  group = augroup,
  callback = function()
    local ok_l, layout = pcall(require, "codediff.ui.layout")
    if not ok_l then return end
    for tabpage, _ in pairs(session.get_active_diffs()) do
      pcall(layout.arrange, tabpage)
    end
  end,
})
```

## Test

Regression test in `tests/ui/layout_spec.lua`:
1. Creates a real session via `session.create_session()` with a configured panel width
2. Calls `cleanup.setup_autocmds()` to install the autocmds (normally done by `view.create()`'s once-guard)
3. Pins layout, sabotages the panel width to 90
4. Fires `doautocmd VimResized`
5. Asserts width is restored within the file's existing `assert_width_near` tolerance

Verified the test body end-to-end via a standalone reproducer; plenary harness can't run locally (segfault on nvim-0.12-nightly, separate issue #367) but CI uses stable nvim where it runs cleanly.

Closes #346