### PR TITLE
fix(ui): disable spell on explorer and history panel windows

### DIFF
--- a/lua/codediff/ui/explorer/render.lua
+++ b/lua/codediff/ui/explorer/render.lua
@@ -88,6 +88,7 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
       wrap = false,
       signcolumn = "no",
       foldcolumn = "0",
+      spell = false,
       winfixwidth = true,
       winfixheight = true,
     },

--- a/lua/codediff/ui/history/render.lua
+++ b/lua/codediff/ui/history/render.lua
@@ -130,6 +130,7 @@ function M.create(commits, git_root, tabpage, width, opts)
       wrap = false,
       signcolumn = "no",
       foldcolumn = "0",
+      spell = false,
     },
   })
 


### PR DESCRIPTION
## What

Adds `spell = false` to the win_options of the explorer panel (issue #338) and history panel windows. Without it, both panels inherit the user's global `spell` setting, and since their content is filenames / commit metadata — not natural-language prose — every entry gets red-underlined as a "misspelling" (e.g. `init`, `lua`, `config`, `refactor`).

## Scope

| Window | Content | `spell = false`? |
|---|---|---|
| Explorer panel | filenames | ✅ added (this issue) |
| History panel | commit metadata | ✅ added (same bug shape) |
| Diff panes (side-by-side / inline) | **user's actual file content** | ❌ intentionally left alone — user's filetype-aware spell config should govern (e.g. spell on for markdown/gitcommit, off for source code) |

## Test

Verified end-to-end via a headless reproducer: set `vim.opt.spell = true` and parent window `spell = true`, open `:CodeDiff`, assert the explorer window's `vim.wo[winid].spell == false`. Output:

```
Pre-CodeDiff: global=true, win 0=true
Post-CodeDiff explorer window spell: false
✅ FIX WORKS — explorer overrides inherited spell
```

(Test not added to the suite — the change is a single literal-value addition to a window-options table sitting alongside other identical literals like `wrap = false`, `signcolumn = "no"`. The shape of the test would just be "literal in config equals literal on window", which is what static reading already confirms.)

Closes #338