### PR TITLE
fix(highlights): honor reverse flag when deriving diff colors (#366)

### DIFF
--- a/lua/codediff/ui/highlights.lua
+++ b/lua/codediff/ui/highlights.lua
@@ -24,6 +24,22 @@ local function adjust_brightness(color, factor)
   return r * 65536 + g * 256 + b
 end
 
+-- Read the effective background color of a highlight group as Neovim's renderer
+-- would resolve it. Some colorschemes (e.g. built-in `sorbet`) define DiffAdd /
+-- DiffDelete using `fg` plus `reverse = true`; Neovim's renderer swaps fg<->bg
+-- at draw time, so the visually-correct "background" comes from `fg`. Just
+-- reading `hl.bg` produces black/default for those schemes (issue #366).
+-- Returns gui_bg, cterm_bg (either may be nil if neither side is defined).
+local function effective_bg(hl)
+  if not hl then
+    return nil, nil
+  end
+  local gui = (hl.reverse and hl.fg) or hl.bg
+  local cterm_reverse = (hl.cterm and hl.cterm.reverse) or hl.reverse
+  local cterm = (cterm_reverse and hl.ctermfg) or hl.ctermbg
+  return gui, cterm
+end
+
 -- Resolve color from config value (supports highlight group name or direct color)
 -- Returns a table suitable for nvim_set_hl (e.g., { bg = 0x2ea043 })
 local function resolve_color(value, fallback_gui, fallback_cterm)
@@ -55,9 +71,10 @@ local function resolve_color(value, fallback_gui, fallback_cterm)
     else
       -- Assume it's a highlight group name
       local hl = vim.api.nvim_get_hl(0, { name = value, link = false })
+      local gui, cterm = effective_bg(hl)
       return {
-        bg = hl.bg or fallback_gui,
-        ctermbg = hl.ctermbg or fallback_cterm,
+        bg = gui or fallback_gui,
+        ctermbg = cterm or fallback_cterm,
       }
     end
   elseif type(value) == "number" then
@@ -123,7 +140,7 @@ function M.setup()
 
   -- Moved code highlights (derived from DiffChange — the standard "changed" color)
   local diff_change_hl = vim.api.nvim_get_hl(0, { name = "DiffChange", link = false })
-  local move_fallback = diff_change_hl.bg or 0x4f5258
+  local move_fallback = effective_bg(diff_change_hl) or 0x4f5258
   local line_move_color = resolve_color(opts.line_move, move_fallback, base256_color(0, 0, 2))
   vim.api.nvim_set_hl(0, "CodeDiffLineMove", line_move_color)
 
@@ -242,6 +259,19 @@ function M.setup()
     link = "FloatTitle",
     default = true,
   })
+
+  -- Re-derive when the user switches colorscheme at runtime. Without this, the
+  -- CodeDiffLineInsert/Delete colors are frozen to whatever scheme was active
+  -- at first setup() and look wrong under any later :colorscheme change.
+  if not M._colorscheme_autocmd_installed then
+    vim.api.nvim_create_autocmd("ColorScheme", {
+      group = vim.api.nvim_create_augroup("codediff_highlights", { clear = true }),
+      callback = function()
+        M.setup()
+      end,
+    })
+    M._colorscheme_autocmd_installed = true
+  end
 end
 
 return M

--- a/tests/ui/highlights_spec.lua
+++ b/tests/ui/highlights_spec.lua
@@ -1,0 +1,75 @@
+-- Tests for lua/codediff/ui/highlights.lua color resolution.
+-- Specifically guards regression #366: highlight groups that use `fg + reverse`
+-- (e.g. built-in `sorbet`) must be read as bg when populating CodeDiffLineInsert
+-- / CodeDiffLineDelete, because Neovim's renderer swaps fg<->bg at draw time.
+
+local highlights = require("codediff.ui.highlights")
+
+local function reset_codediff()
+  -- Wipe any cached CodeDiff highlights so each test starts clean
+  pcall(vim.api.nvim_set_hl, 0, "CodeDiffLineInsert", {})
+  pcall(vim.api.nvim_set_hl, 0, "CodeDiffLineDelete", {})
+  require("codediff").setup({})
+end
+
+describe("highlights.lua color derivation", function()
+  before_each(reset_codediff)
+
+  it("reads bg directly for colorschemes that use bg-based diff highlights", function()
+    -- Mimic the default convention: DiffAdd uses bg + (optional) fg, no reverse
+    vim.api.nvim_set_hl(0, "DiffAdd", { bg = 0x123456 })
+    vim.api.nvim_set_hl(0, "DiffDelete", { bg = 0x654321 })
+    highlights.setup()
+
+    local insert = vim.api.nvim_get_hl(0, { name = "CodeDiffLineInsert", link = false })
+    local delete = vim.api.nvim_get_hl(0, { name = "CodeDiffLineDelete", link = false })
+    assert.are.equal(0x123456, insert.bg, "Insert bg should come from DiffAdd.bg")
+    assert.are.equal(0x654321, delete.bg, "Delete bg should come from DiffDelete.bg")
+  end)
+
+  it("reads fg when colorscheme uses fg + reverse (regression: #366 sorbet)", function()
+    -- Mimic sorbet's pattern: fg holds the green/red color and reverse=true
+    -- means Neovim renders it as a background at draw time.
+    vim.api.nvim_set_hl(0, "DiffAdd", { fg = 0x00af5f, bg = 0x000000, reverse = true })
+    vim.api.nvim_set_hl(0, "DiffDelete", { fg = 0xd70000, bg = 0x000000, reverse = true })
+    highlights.setup()
+
+    local insert = vim.api.nvim_get_hl(0, { name = "CodeDiffLineInsert", link = false })
+    local delete = vim.api.nvim_get_hl(0, { name = "CodeDiffLineDelete", link = false })
+    assert.are.equal(0x00af5f, insert.bg,
+      "Insert bg should come from DiffAdd.fg when reverse=true")
+    assert.are.equal(0xd70000, delete.bg,
+      "Delete bg should come from DiffDelete.fg when reverse=true")
+  end)
+
+  it("honors cterm.reverse independently of gui reverse", function()
+    -- Some colorschemes set the reverse flag only on the cterm side.
+    vim.api.nvim_set_hl(0, "DiffAdd", {
+      bg = 0x123456,
+      ctermfg = 35,
+      ctermbg = 16,
+      cterm = { reverse = true },
+    })
+    highlights.setup()
+
+    local insert = vim.api.nvim_get_hl(0, { name = "CodeDiffLineInsert", link = false })
+    assert.are.equal(0x123456, insert.bg, "GUI bg unaffected when only cterm reverses")
+    assert.are.equal(35, insert.ctermbg, "Cterm bg should come from ctermfg under cterm.reverse")
+  end)
+
+  it("re-derives on :colorscheme change", function()
+    -- First setup: bg-based DiffAdd
+    vim.api.nvim_set_hl(0, "DiffAdd", { bg = 0x111111 })
+    highlights.setup()
+    local before = vim.api.nvim_get_hl(0, { name = "CodeDiffLineInsert", link = false }).bg
+    assert.are.equal(0x111111, before)
+
+    -- Switch convention by emitting a ColorScheme event with a new DiffAdd
+    vim.api.nvim_set_hl(0, "DiffAdd", { fg = 0x222222, reverse = true })
+    vim.cmd("doautocmd ColorScheme")
+
+    local after = vim.api.nvim_get_hl(0, { name = "CodeDiffLineInsert", link = false }).bg
+    assert.are.equal(0x222222, after,
+      "ColorScheme autocmd should re-derive Insert bg from new DiffAdd")
+  end)
+end)


### PR DESCRIPTION
## What

Fixes wrong CodeDiffLineInsert / CodeDiffLineDelete colors under colorschemes that define DiffAdd/DiffDelete using `fg + reverse = true` instead of `bg` directly. The built-in `sorbet` scheme is the reported case (#366); other examples include some terminal/system themes.

## Root cause

```
:colorscheme sorbet
:lua print(vim.inspect(vim.api.nvim_get_hl(0, {name='DiffAdd',link=false})))
-- { bg = 0, fg = 44895, reverse = true, ... }
```

Neovim's renderer honors `reverse` at draw time — it swaps fg ↔ bg so the visible background is `#00af5f` (green). codediff was reading `hl.bg` directly, getting `0` (black), and producing a wrong "green" derivation.

## Fix

- New `effective_bg(hl)` helper that returns `(gui, cterm)` honoring the reverse flag — both gui-wide (`hl.reverse`) and cterm-side (`hl.cterm.reverse`) — so the value we read matches what Neovim's renderer will draw.
- Apply at both call sites: `resolve_color` (DiffAdd/DiffDelete via `config.options.highlights.line_insert/line_delete`) and the inline `DiffChange` read used for moved-code highlights.
- New `ColorScheme` autocmd re-runs `highlights.setup()` when the user switches scheme at runtime, so the colors don't stay frozen to whatever was active at startup.

## Verification

Tested against 6 colorschemes shipped with Neovim:

| Scheme | DiffAdd shape | Insert.bg before | Insert.bg after |
|---|---|---|---|
| default | bg only | `21795` (#005523) | `21795` ✓ (unchanged) |
| habamax | bg only | `2570531` (#273B23) | `2570531` ✓ (unchanged) |
| **sorbet** | fg + reverse | `0` (black, wrong) | **`44895` (#00af5f, correct)** |
| lunaperche | bg only | `2570531` | `2570531` ✓ |
| retrobox | bg only | `2570531` | `2570531` ✓ |
| wildcharm | bg only | `2570531` | `2570531` ✓ |

5 of 6 are byte-identical to pre-fix output → no regression on common schemes. Sorbet flips from wrong to correct.

Runtime switch (`:colorscheme habamax → :colorscheme sorbet`) also verified to re-derive correctly via the new `ColorScheme` autocmd.

## Test

Adds `tests/ui/highlights_spec.lua` (new file, auto-discovered by `run_plenary_tests.sh`) with 4 cases:

- `it("reads bg directly for colorschemes that use bg-based diff highlights")` — guards against regression on the common case
- `it("reads fg when colorscheme uses fg + reverse (regression: #366 sorbet)")` — the bug case
- `it("honors cterm.reverse independently of gui reverse")` — terminal-mode coverage
- `it("re-derives on :colorscheme change")` — runtime switch coverage

All 4 cases pass standalone. Plenary harness runs them in CI via the existing auto-discovery in `run_plenary_tests.sh` (local plenary segfaults on nvim-0.12-nightly per #367 — separate issue).

Closes #366