### PR TITLE
fix(inline): prevent flicker and cursor reset for staged newly-added files (#401)

### DIFF
--- a/lua/codediff/ui/view/inline_view.lua
+++ b/lua/codediff/ui/view/inline_view.lua
@@ -549,30 +549,17 @@ function M.show_single_file(tabpage, file_path, opts)
   -- Load the file
   local file_bufnr
   if opts.revision and opts.git_root then
-    -- Virtual file: create scratch buffer and fetch content
-    file_bufnr = vim.api.nvim_create_buf(false, true)
-    vim.bo[file_bufnr].buftype = "nofile"
+    -- Virtual file: reuse a buffer keyed by (git_root, revision, path) via the
+    -- codediff:// URL scheme. This guarantees a stable bufnr across repeated
+    -- calls (same fix as side_by_side.load_virtual_file). The BufReadCmd in
+    -- core/virtual_file.lua handles content fetching and intentionally avoids
+    -- setting filetype to prevent LSP attach crashes on the custom URI scheme.
+    local virtual_file = require("codediff.core.virtual_file")
+    local url = virtual_file.create_url(opts.git_root, opts.revision, opts.rel_path or file_path)
+    file_bufnr = vim.fn.bufadd(url)
+    vim.fn.bufload(file_bufnr)
     vim.api.nvim_win_set_buf(mod_win, file_bufnr)
     welcome_window.sync(mod_win)
-    local ft = vim.filetype.match({ filename = opts.rel_path or file_path })
-    if ft then
-      vim.bo[file_bufnr].filetype = ft
-    end
-
-    local git = require("codediff.core.git")
-    git.get_file_content(opts.revision, opts.git_root, opts.rel_path or file_path, function(err, lines)
-      vim.schedule(function()
-        if not vim.api.nvim_buf_is_valid(file_bufnr) then
-          return
-        end
-        if err then
-          lines = {}
-        end
-        vim.bo[file_bufnr].modifiable = true
-        vim.api.nvim_buf_set_lines(file_bufnr, 0, -1, false, lines)
-        vim.bo[file_bufnr].modifiable = false
-      end)
-    end)
   else
     -- Real file
     file_bufnr = vim.fn.bufadd(file_path)

--- a/tests/ui/view/inline_explorer_spec.lua
+++ b/tests/ui/view/inline_explorer_spec.lua
@@ -321,4 +321,116 @@ describe("Inline diff with explorer", function()
     vim.fn.delete(orig_path)
     vim.fn.delete(mod_path)
   end)
+
+  -- =========================================================================
+  -- Test 5: Repeated show_single_file for the same real file keeps bufnr stable
+  -- =========================================================================
+  -- Regression test for #401 (real-file path). bufadd-based loading guarantees
+  -- the same bufnr for the same file path, so the window swap is a no-op and
+  -- the cursor is preserved across explorer refresh ticks.
+  it("Repeated show_single_file with same real file keeps bufnr stable", function()
+    local temp_dir = get_temp_dir()
+    local _, tabpage = create_explorer_placeholder(temp_dir)
+
+    local file_path = get_temp_path("inline_dedup_real.txt")
+    vim.fn.writefile({ "line one", "line two", "line three" }, file_path)
+
+    inline_view.show_single_file(tabpage, file_path)
+    vim.cmd("redraw")
+    vim.wait(200, function()
+      local s = lifecycle.get_session(tabpage)
+      return s and s.modified_path == file_path
+    end, 20)
+
+    local session_first = lifecycle.get_session(tabpage)
+    assert.is_not_nil(session_first, "Session should exist after first call")
+    local bufnr_first = session_first.modified_bufnr
+    assert.is_true(vim.api.nvim_buf_is_valid(bufnr_first), "First bufnr should be valid")
+
+    -- Place the cursor on line 3 to detect any reset
+    local mod_win = session_first.modified_win
+    if mod_win and vim.api.nvim_win_is_valid(mod_win) then
+      pcall(vim.api.nvim_win_set_cursor, mod_win, { 3, 0 })
+    end
+
+    for _ = 1, 4 do
+      inline_view.show_single_file(tabpage, file_path)
+    end
+
+    local session_after = lifecycle.get_session(tabpage)
+    assert.equal(bufnr_first, session_after.modified_bufnr,
+      "Repeated show_single_file should not change modified_bufnr (got "
+        .. tostring(session_after.modified_bufnr) .. ", expected " .. tostring(bufnr_first) .. ")")
+
+    vim.fn.delete(file_path)
+  end)
+
+  -- =========================================================================
+  -- Test 6: Repeated show_single_file for staged virtual file keeps bufnr
+  -- stable (the original #401 scenario)
+  -- =========================================================================
+  -- Previously the virtual-file branch did vim.api.nvim_create_buf(false, true)
+  -- on every call, so each refresh tick swapped a fresh scratch buffer into
+  -- the modified window and reset the cursor. The fix replaces that with
+  -- bufadd(virtual_file.create_url(...)), which returns a stable bufnr keyed
+  -- by (git_root, revision, path) — same pattern as side_by_side.lua.
+  it("Repeated show_single_file for staged virtual file keeps bufnr stable (#401)", function()
+    if vim.fn.executable("git") ~= 1 then
+      pending("git not available")
+      return
+    end
+
+    -- Create a real git repo with a staged newly-added file
+    local repo = vim.fn.tempname()
+    vim.fn.mkdir(repo, "p")
+    local function git(args)
+      local out = vim.fn.system({ "git", "-C", repo, unpack(args) })
+      assert(vim.v.shell_error == 0, "git " .. table.concat(args, " ") .. " failed: " .. out)
+    end
+    git({ "init", "-q" })
+    git({ "config", "user.email", "t@t" })
+    git({ "config", "user.name", "t" })
+
+    local rel = "newfile.txt"
+    vim.fn.writefile({ "alpha", "beta", "gamma", "delta" }, repo .. "/" .. rel)
+    git({ "add", rel })
+
+    local _, tabpage = create_explorer_placeholder(repo)
+
+    inline_view.show_single_file(tabpage, rel, {
+      revision = ":0",
+      git_root = repo,
+      rel_path = rel,
+      side = "modified",
+    })
+
+    vim.cmd("redraw")
+    vim.wait(500, function()
+      local s = lifecycle.get_session(tabpage)
+      return s and s.modified_revision == ":0" and s.modified_path == rel
+    end, 20)
+
+    local session_first = lifecycle.get_session(tabpage)
+    assert.is_not_nil(session_first, "Session should exist after first call")
+    local bufnr_first = session_first.modified_bufnr
+    assert.is_true(vim.api.nvim_buf_is_valid(bufnr_first), "First bufnr should be valid")
+    assert.equal(":0", session_first.modified_revision, "modified_revision should be :0")
+
+    -- Repeated calls — would churn bufnr without #401 fix
+    for _ = 1, 5 do
+      inline_view.show_single_file(tabpage, rel, {
+        revision = ":0",
+        git_root = repo,
+        rel_path = rel,
+        side = "modified",
+      })
+    end
+
+    local session_after = lifecycle.get_session(tabpage)
+    assert.equal(bufnr_first, session_after.modified_bufnr,
+      "Staged virtual file: bufnr must stay stable across repeated show_single_file calls (got "
+        .. tostring(session_after.modified_bufnr) .. ", expected " .. tostring(bufnr_first) .. ")")
+
+    vim.fn.delete(repo, "rf")
+  end)
 end)


### PR DESCRIPTION
## Summary

Fixes #401 — inline layout flickered and reset the cursor when viewing staged newly-added files. Side-by-side was unaffected.

## Root cause

`inline_view.show_single_file` allocated a fresh scratch buffer via `nvim_create_buf(false, true)` on every call for virtual files (revision-based content). Each git fs_event refresh tick (~500ms) re-invoked it, swapped a new bufnr into the modified window, and reset the cursor.

The side-by-side equivalent (`load_virtual_file` in `side_by_side.lua:790`) already used `bufadd(virtual_file.create_url(...))` — which returns a stable bufnr keyed by `(git_root, revision, path)`. Inline simply missed the trick. This PR brings inline in line with the existing convention.

## Why only staged newly-added inline showed it

| Path | Bufnr stability |
|---|---|
| Inline + virtual revision (`A`/`D` with rev) | **broken** — `nvim_create_buf` churns |
| Inline + real file (`??`, unstaged) | OK — `bufadd(file_path)` reuses |
| Side-by-side + any single-file virtual | OK — `load_virtual_file` already uses `bufadd(create_url)` |
| Tracked-file diff (status `M`) | OK — `view.update` pins buffers |

Status `??` in inline didn't flicker because it hit the real-file branch. `D` inline had the same latent flicker but rarely surfaced (viewing a deleted file while git is changing). Fixed as a side effect.

## Empirical confirmation

Probe driving the explorer with simulated refresh ticks, observing `session.modified_bufnr` and cursor line:

**Before:**
```
INITIAL: bufnr=10  cursor.line=5
REFRESH #1: bufnr=10  cursor.line=5
REFRESH #2: bufnr=12  cursor.line=1   ← new buf, cursor reset
REFRESH #3: bufnr=12  cursor.line=1
REFRESH #4: bufnr=14  cursor.line=1
REFRESH #5: bufnr=16  cursor.line=1
```

**After:**
```
INITIAL: bufnr=6  cursor.line=5
REFRESH #1: bufnr=6  cursor.line=5
REFRESH #2: bufnr=6  cursor.line=5
REFRESH #3: bufnr=6  cursor.line=5
REFRESH #4: bufnr=6  cursor.line=5
REFRESH #5: bufnr=6  cursor.line=5
```

## Changes

### `lua/codediff/ui/view/inline_view.lua`
Replace the `nvim_create_buf` virtual-file branch with `bufadd(virtual_file.create_url(opts.git_root, opts.revision, opts.rel_path or file_path))` + `bufload`. Mirrors `side_by_side.load_virtual_file` exactly. `BufReadCmd` in `core/virtual_file.lua` handles content loading and intentionally avoids setting `filetype` to prevent LSP attach crashes on the `codediff://` URI scheme.

### `tests/ui/view/inline_explorer_spec.lua`
+2 tests:
- Test 5: Repeated `show_single_file` for a real file keeps `modified_bufnr` stable.
- Test 6: Repeated `show_single_file` for a staged virtual file (`:0`) keeps `modified_bufnr` stable. Direct regression test for #401.

## Testing

All 19 regression-relevant spec files pass (172 tests, 0 failures), including:
- `inline_explorer_spec.lua` (6) — includes new tests
- `inline_standalone_spec.lua` (14)
- `inline_history_spec.lua` (4)
- `inline_interaction_spec.lua` (12)
- `layout_toggle_spec.lua` (13)
- `conflict_dedup_spec.lua` (4)
- `view_spec.lua` (14)
- `explorer_staging_spec.lua` (3)
- `virtual_file_lsp_spec.lua` (2)
- + others

## Benefits

- Stops user-visible flicker and cursor reset reported in #401
- Mirrors the existing `side_by_side.load_virtual_file` convention — no new patterns introduced
- Minimal diff (~9 LoC change + tests) — easy to review
- No public API changes
- Fixes the latent same-class flicker in deleted-file inline view

## Follow-up (not in this PR)

`on_file_select` still has no dedup for the status `A`/`??`/`D` early-return branches in either layout. With this fix, that's a wasted-CPU issue (calls to `inline.clear`, `auto_refresh.disable`, `lifecycle.update_*`, `keymaps.setup_all_keymaps`, `layout.arrange` on every ~500ms tick) but no longer a visible bug, since bufnr is now stable.

The recurring "missing dedup branch" bug class (#308 staged-rename, #320 conflict, #401 staged-add) suggests `on_file_select` should be refactored to a `resolve_view → render` pipeline with a single dedup site shared across layouts. Worth a follow-up issue to capture the technical debt.
