### PR TITLE
fix(explorer): show deleted-file content in single-revision mode (#390)

### DIFF
--- a/lua/codediff/ui/explorer/render.lua
+++ b/lua/codediff/ui/explorer/render.lua
@@ -303,7 +303,13 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
         local sess = lifecycle.get_session(tabpage)
         local is_inline = sess and sess.layout == "inline"
 
-        if base_revision and target_revision and target_revision ~= "WORKING" then
+        -- Whenever the explorer is anchored to a base_revision (single-rev
+        -- like `:CodeDiff HEAD~5` OR revision-revision like `:CodeDiff A B`),
+        -- the deleted file's content lives at base_revision; reading from
+        -- HEAD/:0 yields nothing because the file is already gone there.
+        -- The HEAD/:0 branch is only correct for plain explorer mode
+        -- (no base_revision). Fixes #390.
+        if base_revision then
           if is_inline then
             require("codediff.ui.view.inline_view").show_single_file(tabpage, file_path, {
               revision = base_revision,

--- a/tests/ui/explorer/issue_390_spec.lua
+++ b/tests/ui/explorer/issue_390_spec.lua
@@ -1,0 +1,149 @@
+-- Regression test for https://github.com/esmuellert/codediff.nvim/issues/390
+-- Selecting a deleted file in `:CodeDiff HEAD~N` mode must load its content
+-- from HEAD~N, not from `:0`/`HEAD` (where the file is already gone).
+
+local h = require('tests.helpers')
+
+describe('Issue #390 regression — deleted file shows content in revision mode', function()
+  local repo
+
+  before_each(function()
+    h.ensure_plugin_loaded()
+    repo = h.create_temp_git_repo()
+  end)
+
+  after_each(function()
+    if repo then repo.cleanup() end
+    while vim.fn.tabpagenr('$') > 1 do
+      vim.cmd('tabclose')
+    end
+  end)
+
+  it('selecting a deleted file in `:CodeDiff HEAD~N` mode loads its content from HEAD~N', function()
+    repo.write_file('to_delete.txt', {
+      "first line",
+      "second line",
+      "third line",
+    })
+    repo.write_file('keep.txt', { "v1" })
+    repo.git("add .")
+    repo.git("commit -m c0")        -- HEAD~5
+
+    repo.write_file('keep.txt', { "v1", "v2" })
+    repo.git("commit -am c1")
+
+    repo.write_file('keep.txt', { "v1", "v2", "v3" })
+    repo.git("commit -am c2")
+
+    repo.git("rm to_delete.txt")
+    repo.git("commit -m c3-delete")
+
+    repo.write_file('keep.txt', { "v1", "v2", "v3", "v4" })
+    repo.git("commit -am c4")
+
+    repo.write_file('keep.txt', { "v1", "v2", "v3", "v4", "v5" })
+    repo.git("commit -am c5")
+
+    local diff_out = repo.git("diff HEAD~5 -- to_delete.txt")
+    assert.is_true(
+      diff_out:find("deleted file mode", 1, true) ~= nil,
+      "git diff HEAD~5 should report to_delete.txt as deleted"
+    )
+
+    vim.cmd("edit " .. repo.dir .. "/keep.txt")
+    local commands = require("codediff.commands")
+    commands.vscode_diff({ fargs = { "HEAD~5" } })
+
+    local lifecycle = require("codediff.ui.lifecycle")
+
+    -- Wait for the explorer to populate.
+    local ok = vim.wait(8000, function()
+      for _, tp in ipairs(vim.api.nvim_list_tabpages()) do
+        local sess = lifecycle.get_session(tp)
+        if sess and sess.explorer and sess.explorer.tree and sess.explorer.tree._nodes then
+          return true
+        end
+      end
+      return false
+    end, 50)
+    assert.is_true(ok, "explorer did not become ready within timeout")
+
+    -- Locate the explorer and walk its tree to find to_delete.txt.
+    local explorer
+    for _, tp in ipairs(vim.api.nvim_list_tabpages()) do
+      local s = lifecycle.get_session(tp)
+      if s and s.explorer then
+        explorer = s.explorer
+        break
+      end
+    end
+    assert.is_not_nil(explorer, "no explorer session created")
+    assert.is_function(explorer.on_file_select, "explorer.on_file_select missing")
+
+    local file_data
+    local function walk(node, depth)
+      if type(node) ~= "table" or depth > 8 then return end
+      if node.data and type(node.data) == "table" then
+        local p = node.data.path or ""
+        if p:find("to_delete.txt", 1, true) and node.data.status == "D" then
+          file_data = node.data
+          return
+        end
+      end
+      for k, v in pairs(node) do
+        if file_data then return end
+        if type(v) == "table" and k ~= "parent" then walk(v, depth + 1) end
+      end
+    end
+    walk(explorer.tree, 0)
+
+    assert.is_not_nil(file_data,
+      "explorer did not list to_delete.txt with status 'D' in revision mode")
+    assert.equal("D", file_data.status)
+
+    -- Trigger the same code path that the user's <CR> keymap hits.
+    explorer.on_file_select(file_data, { force = true })
+
+    -- Give the virtual-file load callback time to land.
+    local diff_ready = vim.wait(5000, function()
+      for _, tp in ipairs(vim.api.nvim_list_tabpages()) do
+        local s = lifecycle.get_session(tp)
+        if s and s.original_bufnr and vim.api.nvim_buf_is_valid(s.original_bufnr) then
+          local lines = vim.api.nvim_buf_get_lines(s.original_bufnr, 0, -1, false)
+          if #lines >= 3 then return true end
+        end
+      end
+      return false
+    end, 50)
+
+    -- Verify the original-side buffer now contains the deleted file's
+    -- pre-deletion content. Pre-fix this was empty.
+    local sess
+    for _, tp in ipairs(vim.api.nvim_list_tabpages()) do
+      local s = lifecycle.get_session(tp)
+      if s and s.original_bufnr then sess = s; break end
+    end
+    assert.is_not_nil(sess, "no diff session after selecting deleted file")
+
+    local orig_lines = vim.api.nvim_buf_get_lines(sess.original_bufnr, 0, -1, false)
+    local orig_text = table.concat(orig_lines, "\n")
+
+    assert.is_true(diff_ready,
+      "ORIGINAL buffer never received deleted file's content. Pre-fix bug: it stayed empty.\nGot lines: "
+        .. vim.inspect(orig_lines))
+
+    for _, expected in ipairs({ "first line", "second line", "third line" }) do
+      assert.is_true(
+        orig_text:find(expected, 1, true) ~= nil,
+        "ORIGINAL buffer must contain '" .. expected .. "' from HEAD~5:to_delete.txt. Got:\n" .. orig_text
+      )
+    end
+
+    -- And the revision the buffer is loaded from must NOT be the index
+    -- (where the file is gone). Pre-fix this was ":0".
+    assert.is_not.equal(":0", sess.original_revision,
+      "ORIGINAL revision must not be ':0' for revision mode — that's the bug")
+    assert.is_not.equal("HEAD", sess.original_revision,
+      "ORIGINAL revision must not be 'HEAD' for revision mode — that's the bug")
+  end)
+end)


### PR DESCRIPTION
## Summary

Closes #390. In single-revision mode (`:CodeDiff HEAD~5`), selecting a deleted file in the explorer showed an empty original pane. The deleted-file branch in `explorer/render.lua` only read from `base_revision` when *both* revisions were set AND `target_revision ~= \"WORKING\"`. In single-revision mode `target_revision` is `\"WORKING\"`, so the code fell through to the `HEAD`/`:0` reader — but the file is already gone from both, so the read returned nothing.

The fix: read from `base_revision` whenever it is set. That covers both single-revision mode and the existing revision-revision mode, and leaves plain explorer mode (no `base_revision`) on the `HEAD`/`:0` path it actually needs.

## Behavior table

| Mode | `base_revision` | `target_revision` | Old branch | New branch |
|---|---|---|---|---|
| `:CodeDiff A B` | `A` | `B` | top (read `base_revision`) | top (unchanged) |
| `:CodeDiff HEAD~5` | `HEAD~5` | `\"WORKING\"` | **bottom (read `:0` — empty, bug)** | top (read `base_revision`) |
| `:CodeDiff` (no rev) | `nil` | `nil`/`\"WORKING\"` | bottom (read `:0`/`HEAD` — correct) | bottom (unchanged) |

Only the buggy cell of the truth table changes.

## Test plan

- [x] All 295 UI tests pass (was 294 + 1 new regression test).
- [x] New `tests/ui/explorer/issue_390_spec.lua` drives `:CodeDiff HEAD~5` against a real repo with a file deleted 3 commits ago and asserts the original-pane buffer contains the deleted file's pre-deletion content (and `original_revision` is no longer `:0`).
- [x] Verified the new test fails on `main` and passes on this branch.
- [x] Manually validated against the reproducer at `/tmp/codediff-issue-390`.

## Compatibility

Non-breaking. The two `and` clauses removed from the condition were the original author's way of detecting \"revision-revision mode specifically\" (added in `eec3007`). Single-revision mode has the same correctness requirement (load from `base_revision`) but was missed. The third path (plain explorer mode without `base_revision`) is untouched because `if base_revision then` evaluates `false` there. The symmetric added-file branch at line 265 was deliberately left alone — it has a third correct branch (`show_untracked_file` reading the working tree) that's the right behavior for single-revision mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)