### PR TITLE
fix(conflict): don't enable auto_refresh on input panes (#387)

### DIFF
--- a/lua/codediff/ui/view/side_by_side.lua
+++ b/lua/codediff/ui/view/side_by_side.lua
@@ -235,8 +235,6 @@ function M.create(session_config, filetype, on_ready)
                   conflict.setup_keymaps(tabpage)
                 end
               )
-              -- Setup auto-refresh for consistency (both buffers are virtual in conflict mode)
-              setup_auto_refresh(original_info.bufnr, modified_info.bufnr, true, true)
 
               -- Setup result window and keymaps
               local success = setup_conflict_result_window(tabpage, session_config, original_win, modified_win, base_lines, conflict_diffs, false)
@@ -510,8 +508,6 @@ function M.update(tabpage, session_config, auto_scroll_to_first_hunk)
             lifecycle.update_revisions(tabpage, session_config.original_revision, session_config.modified_revision)
             lifecycle.update_diff_result(tabpage, conflict_diffs.base_to_modified_diff)
             lifecycle.update_changedtick(tabpage, vim.api.nvim_buf_get_changedtick(original_info.bufnr), vim.api.nvim_buf_get_changedtick(modified_info.bufnr))
-            setup_auto_refresh(original_info.bufnr, modified_info.bufnr, true, true)
-
             local is_explorer_mode = session.mode == "explorer"
             local success = setup_conflict_result_window(tabpage, session_config, original_win, modified_win, base_lines, conflict_diffs, true)
             if success then

--- a/tests/ui/conflict/issue_387_spec.lua
+++ b/tests/ui/conflict/issue_387_spec.lua
@@ -1,0 +1,103 @@
+-- Regression test for https://github.com/esmuellert/codediff.nvim/issues/387
+-- In conflict mode, both input panes must show changes with the same green
+-- "added relative to BASE" highlight (matches VSCode's
+-- mergeEditor.change.background) — and that coloring must survive any
+-- TextChanged-like event without being overwritten by the normal diff
+-- renderer's red/green scheme.
+
+local h = require('tests.helpers')
+
+describe('Issue #387 regression — conflict-mode input panes stay green on TextChanged', function()
+  local repo
+
+  before_each(function()
+    h.ensure_plugin_loaded()
+    repo = h.create_temp_git_repo()
+  end)
+
+  after_each(function()
+    if repo then repo.cleanup() end
+    while vim.fn.tabpagenr('$') > 1 do
+      vim.cmd('tabclose')
+    end
+  end)
+
+  it('both input panes use LineInsert (green) and survive TextChanged', function()
+    repo.write_file('file.txt', { "line 1", "line 2", "line 3", "line 4", "line 5" })
+    repo.git("add file.txt")
+    repo.git("commit -m c0")
+
+    repo.git("checkout -b feature")
+    repo.write_file('file.txt', { "line 1", "line 2", "line 3 (feature)", "line 4", "line 5" })
+    repo.git("commit -am feature")
+
+    repo.git("checkout main")
+    repo.write_file('file.txt', { "line 1", "line 2", "line 3 (main)", "line 4", "line 5" })
+    repo.git("commit -am main")
+
+    local merge_out = repo.git("merge feature --no-edit")
+    assert.is_true(merge_out:find("CONFLICT", 1, true) ~= nil, "merge must conflict")
+
+    -- Open codediff in conflict mode using the same session_config shape
+    -- the :CodeDiff merge command (and neogit's integration) builds.
+    vim.cmd("edit " .. repo.dir .. "/file.txt")
+    local view = require("codediff.ui.view")
+    local ready = false
+    view.create({
+      mode = "standalone",
+      git_root = repo.dir,
+      original_path = "file.txt",
+      modified_path = "file.txt",
+      original_revision = ":3",
+      modified_revision = ":2",
+      conflict = true,
+    }, "", function() ready = true end)
+
+    assert.is_true(vim.wait(15000, function() return ready end, 50),
+      "view.create did not become ready")
+
+    local lifecycle = require("codediff.ui.lifecycle")
+    local sess
+    for _, tp in ipairs(vim.api.nvim_list_tabpages()) do
+      local s = lifecycle.get_session(tp)
+      if s and s.result_bufnr then sess = s; break end
+    end
+    assert.is_not_nil(sess)
+
+    local highlights = require("codediff.ui.highlights")
+    local function counts(bufnr)
+      local marks = vim.api.nvim_buf_get_extmarks(bufnr, highlights.ns_highlight, 0, -1, { details = true })
+      local g = {}
+      for _, m in ipairs(marks) do
+        local d = m[4] or {}
+        if d.hl_group then g[d.hl_group] = (g[d.hl_group] or 0) + 1 end
+      end
+      return g
+    end
+
+    local function assert_green_only(g, label)
+      assert.is_true((g.CodeDiffLineInsert or 0) > 0,
+        label .. " must have CodeDiffLineInsert highlights, got: " .. vim.inspect(g))
+      assert.equal(0, g.CodeDiffLineDelete or 0,
+        label .. " must NOT have CodeDiffLineDelete (red); VSCode uses one color for both inputs. Got: "
+          .. vim.inspect(g))
+      assert.equal(0, g.CodeDiffCharDelete or 0,
+        label .. " must NOT have CodeDiffCharDelete. Got: " .. vim.inspect(g))
+    end
+
+    -- Initial render must paint both panes green (matches VSCode).
+    assert_green_only(counts(sess.original_bufnr), "ORIGINAL (incoming/theirs) initial")
+    assert_green_only(counts(sess.modified_bufnr), "MODIFIED (current/ours) initial")
+
+    -- Fire TextChanged on both input buffers (simulates user clicking into
+    -- them, plugin decorating, etc.). Pre-fix, this triggered auto_refresh
+    -- which overwrote ORIGINAL with CodeDiffLineDelete (red). Post-fix the
+    -- panes must keep the same green coloring.
+    vim.api.nvim_exec_autocmds("TextChanged", { buffer = sess.original_bufnr, modeline = false })
+    vim.api.nvim_exec_autocmds("TextChanged", { buffer = sess.modified_bufnr, modeline = false })
+    vim.wait(500)
+
+    assert_green_only(counts(sess.original_bufnr), "ORIGINAL (incoming/theirs) after TextChanged")
+    assert_green_only(counts(sess.modified_bufnr), "MODIFIED (current/ours) after TextChanged")
+  end)
+end)


### PR DESCRIPTION
## Summary

Closes #387. In conflict mode, the incoming/theirs pane showed changes in green (CodeDiffLineInsert) on initial open but flipped to red (CodeDiffLineDelete) the moment any plugin-triggered \`TextChanged\` event fired on it — the reporter described this as \"highlights are wrongly colored... corrected when I click/go into theirs.\"

Two renderers were disagreeing about the conflict-pane coloring:

| Renderer | left/incoming | right/current |
|---|---|---|
| \`render_merge_view\` (initial) | green | green |
| \`render_diff\` (via auto_refresh on TextChanged) | red | green |

Checked VSCode's [\`mergeEditor/browser/view/colors.ts\`](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/mergeEditor/browser/view/colors.ts) and [\`mergeEditor.css\`](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/mergeEditor/browser/view/media/mergeEditor.css): VSCode applies one shared class \`.merge-editor-diff\` (= \`mergeEditor.change.background\`, green) to **both** input panes. Red (\`mergeEditor.changeBase.background\`) is reserved for the BASE pane only. So the **initial** \`render_merge_view\` was correct and \`render_diff\` overwriting it via auto_refresh was the bug.

The input panes in conflict mode are read-only virtual buffers loaded from git stages \`:2\` / \`:3\`. They can't be edited, can't change on disk, so auto_refresh has nothing meaningful to track on them. Removing the two \`setup_auto_refresh\` calls fixes the bug at its source.

The Result-pane auto_refresh (\`enable_for_result\` in \`conflict_window.lua\`) is untouched — that one is meaningful (the user *does* edit the Result pane to resolve conflicts).

## Test plan

- [x] All 296 UI tests pass (was 295 + 1 new regression test).
- [x] New \`tests/ui/conflict/issue_387_spec.lua\` builds a real merge conflict, opens codediff in conflict mode, asserts both panes are \`CodeDiffLineInsert\` (green), fires \`TextChanged\` on both buffers, and re-asserts both are still green.
- [x] A/B verified: regression test fails on \`main\`, passes on this branch.
- [x] Reproduced and validated end-to-end in a dedicated Ubuntu sandbox (\`codediff-repro-sandbox\`) with neovim 0.11.5, real git merge conflict, full codediff stack.

## Compatibility

Non-breaking. The removed code wasn't providing any observable behavior (input panes are readonly virtual buffers — auto_refresh had nothing to refresh). Removing it eliminates a known wrong-color regression with zero functional loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)