### PR TITLE
fix(navigation): default cycle_hunks_across_files to false (#412)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ https://github.com/user-attachments/assets/64c41f01-dffe-4318-bce4-16eec8de356e
       conflict_result_width_ratio = { 1, 1, 1 }, -- Width ratio for center layout panes {left, center, right} (e.g., {1, 2, 1} for wider result)
       cycle_next_hunk = true,             -- Wrap around when navigating hunks (]c/[c): false to stop at first/last
       cycle_next_file = true,             -- Wrap around when navigating files (]f/[f): false to stop at first/last
-      cycle_hunks_across_files = true,    -- ]c/[c at file boundary hops to first/last hunk of next/prev file (explorer/history)
+      cycle_hunks_across_files = false,   -- ]c/[c at file boundary hops to first/last hunk of next/prev file (explorer/history)
       jump_to_first_change = true,        -- Auto-scroll to first change when opening a diff: false to stay at same line
       highlight_priority = 100,           -- Priority for line-level diff highlights (increase to override LSP highlights)
       compute_moves = false,              -- Detect moved code blocks (opt-in, matches VSCode experimental.showMoves)

--- a/doc/codediff.txt
+++ b/doc/codediff.txt
@@ -197,7 +197,7 @@ Setup entry point:
       compute_moves = false,
       compact_context_lines = 3,
       compact_sync_folds = true,
-      cycle_hunks_across_files = true,
+      cycle_hunks_across_files = false,
     },
     explorer = {
       position = "left",

--- a/lua/codediff/config.lua
+++ b/lua/codediff/config.lua
@@ -41,7 +41,7 @@ M.defaults = {
     conflict_result_width_ratio = { 1, 1, 1 }, -- Width ratio for center layout panes {left, center, right} (e.g., {1, 2, 1} for wider result)
     cycle_next_hunk = true, -- Wrap around when navigating hunks (]c/[c): true = cycle, false = stop at first/last
     cycle_next_file = true, -- Wrap around when navigating files (]f/[f): true = cycle, false = stop at first/last
-    cycle_hunks_across_files = true, -- ]c/[c at file boundary jumps to first/last hunk of next/prev file (explorer/history mode)
+    cycle_hunks_across_files = false, -- ]c/[c at file boundary jumps to first/last hunk of next/prev file (explorer/history mode)
     jump_to_first_change = true, -- Auto-scroll to first change when opening a diff: true = jump to first hunk, false = stay at same line
     highlight_priority = 100, -- Priority for line-level diff highlights (increase to override LSP highlights)
     compute_moves = false, -- Detect moved code blocks (opt-in, may increase diff computation time)


### PR DESCRIPTION
## Summary

Fixes #412. PR #410 introduced the `cycle_hunks_across_files` option but accidentally set its default to `true`, silently changing the behavior of `]c` / `[c` so that pressing them on the last hunk of a file would jump to the next file instead of cycling within the current file.

This restores the legacy / vim-diff behavior as the default. Users who want cross-file cycling can opt in:

```lua
diff = {
  cycle_hunks_across_files = true,
}
```

## Changes

- `lua/codediff/config.lua`: default flipped to `false`
- `README.md`: updated documented default
- `doc/codediff.txt`: updated documented default

## Test plan

- [x] Existing tests in `tests/ui/view/cycle_hunks_across_files_spec.lua` already set the option explicitly per case, so both ON and OFF paths remain covered.
- [x] No production logic changed — only the default value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)