### PR TITLE
feat(ui): support `mini.icons` as the file icons provider

### DIFF
--- a/lua/codediff/ui/explorer/nodes.lua
+++ b/lua/codediff/ui/explorer/nodes.lua
@@ -4,6 +4,7 @@ local M = {}
 
 local Tree = require("codediff.ui.lib.tree")
 local Line = require("codediff.ui.lib.line")
+local tree_utils = require("codediff.ui.lib.tree_utils")
 local config = require("codediff.config")
 
 -- Merge artifact patterns (created by git mergetool)
@@ -65,16 +66,6 @@ function M.filter_merge_artifacts(files)
   return filtered
 end
 
--- File icons (basic fallback)
-function M.get_file_icon(path)
-  local has_devicons, devicons = pcall(require, "nvim-web-devicons")
-  if has_devicons then
-    local icon, color = devicons.get_icon(path, nil, { default = true })
-    return icon or "", color
-  end
-  return "", nil
-end
-
 -- Folder icon (configurable via config, with nerd font defaults)
 function M.get_folder_icon(is_open)
   local explorer_config = config.options.explorer or {}
@@ -91,7 +82,7 @@ end
 function M.create_file_nodes(files, git_root, group)
   local nodes = {}
   for _, file in ipairs(files) do
-    local icon, icon_color = M.get_file_icon(file.path)
+    local icon, icon_color = tree_utils.get_file_icon(file.path)
     local status_info = STATUS_SYMBOLS[file.status] or { symbol = file.status, color = "Normal" }
 
     nodes[#nodes + 1] = Tree.Node({
@@ -214,7 +205,7 @@ function M.create_tree_file_nodes(files, git_root, group)
       else
         -- File node
         local file = item._file
-        local icon, icon_color = M.get_file_icon(file.path)
+        local icon, icon_color = tree_utils.get_file_icon(file.path)
         local status_info = STATUS_SYMBOLS[file.status] or { symbol = file.status, color = "Normal" }
 
         nodes[#nodes + 1] = Tree.Node({

--- a/lua/codediff/ui/history/nodes.lua
+++ b/lua/codediff/ui/history/nodes.lua
@@ -4,6 +4,7 @@ local M = {}
 
 local Tree = require("codediff.ui.lib.tree")
 local Line = require("codediff.ui.lib.line")
+local tree_utils = require("codediff.ui.lib.tree_utils")
 local config = require("codediff.config")
 
 -- Status symbols and colors (reuse from explorer)
@@ -14,16 +15,6 @@ local STATUS_SYMBOLS = {
   R = { symbol = "R", color = "CodeDiffStatusRenamed" },
 }
 
--- File icons (basic fallback)
-function M.get_file_icon(path)
-  local has_devicons, devicons = pcall(require, "nvim-web-devicons")
-  if has_devicons then
-    local icon, color = devicons.get_icon(path, nil, { default = true })
-    return icon or "", color
-  end
-  return "", nil
-end
-
 -- Create commit node with its file children
 -- commit: { hash, short_hash, author, date, date_relative, subject }
 -- files: { { path, status, old_path }, ... }
@@ -32,7 +23,7 @@ function M.create_commit_node(commit, files, git_root)
   local file_nodes = {}
 
   for i, file in ipairs(files) do
-    local icon, icon_color = M.get_file_icon(file.path)
+    local icon, icon_color = tree_utils.get_file_icon(file.path)
     local status_info = STATUS_SYMBOLS[file.status] or { symbol = file.status, color = "Normal" }
 
     file_nodes[#file_nodes + 1] = Tree.Node({
@@ -79,7 +70,7 @@ function M.create_list_file_nodes(files, commit_hash, git_root)
   local file_nodes = {}
 
   for i, file in ipairs(files) do
-    local icon, icon_color = M.get_file_icon(file.path)
+    local icon, icon_color = tree_utils.get_file_icon(file.path)
     local status_info = STATUS_SYMBOLS[file.status] or { symbol = file.status, color = "Normal" }
 
     file_nodes[#file_nodes + 1] = Tree.Node({
@@ -185,7 +176,7 @@ function M.create_tree_file_nodes(files, commit_hash, git_root)
       else
         -- File node
         local file = item._file
-        local icon, icon_color = M.get_file_icon(file.path)
+        local icon, icon_color = tree_utils.get_file_icon(file.path)
         local status_info = STATUS_SYMBOLS[file.status] or { symbol = file.status, color = "Normal" }
 
         nodes[#nodes + 1] = Tree.Node({

--- a/lua/codediff/ui/lib/tree_utils.lua
+++ b/lua/codediff/ui/lib/tree_utils.lua
@@ -1,5 +1,8 @@
 local M = {}
 
+local devicons, mini_icons
+local icons_provider_resolved = false
+
 function M.find_foldable_node(node, tree)
   if node:is_foldable() then
     return node
@@ -154,6 +157,36 @@ function M.setup_fold_keymaps(opts)
       vim.keymap.set("n", key, binding.fn, vim.tbl_extend("force", map_options, { buffer = bufnr, desc = binding.desc }))
     end
   end
+end
+
+-- File icons (basic fallback)
+function M.get_file_icon(path)
+  if not (devicons or mini_icons) then
+    if icons_provider_resolved then
+      return "", nil
+    end
+
+    local ok, mod = pcall(require, "nvim-web-devicons")
+    if ok then
+      devicons = mod
+    else
+      ok, mod = pcall(require, "mini.icons")
+      if ok then
+        mini_icons = mod
+      end
+    end
+
+    icons_provider_resolved = true
+  end
+
+  local icon, color
+  if devicons then
+    icon, color = devicons.get_icon(path, nil, { default = true })
+  elseif mini_icons then
+    icon, color = mini_icons.get("file", path)
+  end
+
+  return icon or "", color
 end
 
 return M


### PR DESCRIPTION
The same function is duplicated in 2 different places, so I moved it to `tree_utils.lua`. Below is a screenshot showing how icons look using [mini.icons](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-icons.md) and Nord theme.

<img width="2115" height="1275" alt="Screenshot_20260620_111400" src="https://github.com/user-attachments/assets/4111a9ee-65b7-480c-81e2-bb9cc91b092b" />
