### PR TITLE
fix(compact): clear stale fold data when switching to new/untracked files

### DIFF
--- a/lua/codediff/ui/view/compact.lua
+++ b/lua/codediff/ui/view/compact.lua
@@ -315,6 +315,12 @@ function M.reapply(tabpage)
 
   local changes = session.stored_diff_result.changes
   if not changes or #changes == 0 then
+    if session.layout == "inline" then
+      if session.modified_win then visible_lines_by_win[session.modified_win] = nil end
+    else
+      if session.original_win then visible_lines_by_win[session.original_win] = nil end
+      if session.modified_win then visible_lines_by_win[session.modified_win] = nil end
+    end
     return
   end
 

--- a/tests/ui/view/compact_spec.lua
+++ b/tests/ui/view/compact_spec.lua
@@ -475,4 +475,70 @@ describe("compact mode (#344)", function()
         "modified pane: corresponding line " .. mod_target .. " should also be inside a closed fold (synced), got " .. mod_after)
     end)
   end)
+
+  -- =====================================================================
+  -- reapply with empty changes (new/untracked file switch)
+  -- =====================================================================
+
+  describe("reapply with empty changes", function()
+    it("clears stale fold data so foldexpr returns '0' for all lines (side-by-side)", function()
+      local original, modified = {}, {}
+      for i = 1, 30 do
+        original[i] = "line " .. i
+        modified[i] = "line " .. i
+      end
+      modified[15] = "line 15 CHANGED"
+
+      local tabpage, session = create_session(original, modified)
+      assert.is_true(compact.enable(tabpage))
+
+      -- foldexpr should return "1" for a line far from the hunk
+      local fold_before = vim.api.nvim_win_call(session.modified_win, function()
+        vim.v.lnum = 1
+        return compact.foldexpr_eval()
+      end)
+      assert.equal("1", fold_before, "line 1 should be foldable before reapply")
+
+      -- Simulate switching to a file with no changes (untracked/new file)
+      session.stored_diff_result = { changes = {}, moves = {} }
+      compact.reapply(tabpage)
+
+      -- After reapply with empty changes, foldexpr should return "0" for all lines
+      for _, win in ipairs({ session.original_win, session.modified_win }) do
+        local result = vim.api.nvim_win_call(win, function()
+          vim.v.lnum = 1
+          return compact.foldexpr_eval()
+        end)
+        assert.equal("0", result,
+          "foldexpr should return '0' after reapply with empty changes (win " .. win .. ")")
+      end
+    end)
+
+    it("clears stale fold data so foldexpr returns '0' for all lines (inline)", function()
+      require("codediff").setup({
+        diff = { layout = "inline", compact_context_lines = 3 },
+      })
+
+      local original, modified = {}, {}
+      for i = 1, 30 do
+        original[i] = "line " .. i
+        modified[i] = "line " .. i
+      end
+      modified[15] = "line 15 CHANGED"
+
+      local tabpage, session = create_session(original, modified)
+      assert.is_true(compact.enable(tabpage))
+
+      -- Simulate switching to a file with no changes
+      session.stored_diff_result = { changes = {}, moves = {} }
+      compact.reapply(tabpage)
+
+      local result = vim.api.nvim_win_call(session.modified_win, function()
+        vim.v.lnum = 1
+        return compact.foldexpr_eval()
+      end)
+      assert.equal("0", result,
+        "foldexpr should return '0' after reapply with empty changes (inline)")
+    end)
+  end)
 end)


### PR DESCRIPTION
When compact mode is active and the user navigates to an untracked or newly added file (empty changes), reapply returned early without clearing visible_lines_by_win. The stale fold data from the previous file caused foldexpr to fold the entire new file.

Fix: Clear the window entries from visible_lines_by_win before the early return so foldexpr_eval returns "0" (unfoldable) for all lines. compact_mode stays true so compact re-engages on the next file with real diffs.