### PR TITLE
feat(explorer): support explorer.position = "right"

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ https://github.com/user-attachments/assets/64c41f01-dffe-4318-bce4-16eec8de356e
 
     -- Explorer panel configuration
     explorer = {
-      position = "left",  -- "left" or "bottom"
+      position = "left",  -- "left", "right", or "bottom"
       hidden = false,  -- Initial visibility state
-      width = 40,         -- Width when position is "left" (columns)
+      width = 40,         -- Width when position is "left" or "right" (columns)
       height = 15,        -- Height when position is "bottom" (lines)
       auto_refresh = true,  -- Auto-refresh file list on focus / git index changes (set false to avoid lag in huge repos; R still refreshes manually)
       indent_markers = true,  -- Show indent markers in tree view (│, ├, └)

--- a/lua/codediff/config.lua
+++ b/lua/codediff/config.lua
@@ -51,7 +51,7 @@ M.defaults = {
 
   -- Explorer panel configuration
   explorer = {
-    position = "left", -- "left" or "bottom"
+    position = "left", -- "left", "right", or "bottom"
     hidden = false, -- Initial visibility state
     width = 40, -- Width when position is "left" (columns)
     height = 15, -- Height when position is "bottom" (lines)

--- a/lua/codediff/ui/layout.lua
+++ b/lua/codediff/ui/layout.lua
@@ -35,7 +35,7 @@ function M.arrange(tabpage)
 
   -- Step 1: Pin panel size (fixed element)
   if panel_visible then
-    if panel_position == "left" then
+    if panel_position == "left" or panel_position == "right" then
       vim.api.nvim_win_set_width(panel_win, panel_config.width)
     else
       vim.api.nvim_win_set_height(panel_win, panel_config.height)
@@ -51,7 +51,7 @@ function M.arrange(tabpage)
     local sole_win = orig_valid and original_win or (mod_valid and modified_win or nil)
     if sole_win then
       if panel_visible then
-        if panel_position == "left" then
+        if panel_position == "left" or panel_position == "right" then
           vim.api.nvim_win_set_width(panel_win, panel_config.width)
           -- Explicitly set diff window to fill remainder
           local remainder = vim.o.columns - panel_config.width - 1
@@ -117,7 +117,7 @@ function M.arrange(tabpage)
 
   -- Step 5: Re-pin panel size (undo disturbance from step 4)
   if panel_visible then
-    if panel_position == "left" then
+    if panel_position == "left" or panel_position == "right" then
       vim.api.nvim_win_set_width(panel_win, panel_config.width)
     else
       vim.api.nvim_win_set_height(panel_win, panel_config.height)

--- a/tests/ui/layout_spec.lua
+++ b/tests/ui/layout_spec.lua
@@ -223,6 +223,44 @@ describe("Layout Manager", function()
   end)
 
   -- =========================================================================
+  -- Case 2b: Explorer right, no result — [orig | mod | expl]
+  -- =========================================================================
+  it("Case 2b: Explorer right — panel gets configured width, diff panes split remainder", function()
+    local panel_width = 35
+    config.options.explorer = { position = "right", width = panel_width }
+
+    vim.cmd("tabnew")
+    local tabpage = vim.api.nvim_get_current_tabpage()
+    local orig_win = vim.api.nvim_get_current_win()
+    local orig_buf = vim.api.nvim_get_current_buf()
+    vim.cmd("vsplit")
+    local mod_win = vim.api.nvim_get_current_win()
+    local mod_buf = vim.api.nvim_get_current_buf()
+
+    local panel = create_panel_split("right", panel_width)
+
+    create_mock_session(tabpage, {
+      mode = "explorer",
+      original_win = orig_win,
+      modified_win = mod_win,
+      original_bufnr = orig_buf,
+      modified_bufnr = mod_buf,
+      panel = panel,
+    })
+
+    layout.arrange(tabpage)
+
+    local panel_w = vim.api.nvim_win_get_width(panel.winid)
+    local orig_w = vim.api.nvim_win_get_width(orig_win)
+    local mod_w = vim.api.nvim_win_get_width(mod_win)
+
+    assert.are.equal(panel_width, panel_w, "Panel should be configured width")
+    assert_width_near(orig_w, mod_w, "Diff panes should be equal width:")
+
+    cleanup_mock_session(tabpage)
+  end)
+
+  -- =========================================================================
   -- Case 3: Explorer bottom, no result — [orig | mod] / [expl]
   -- =========================================================================
   it("Case 3: Explorer bottom — panel gets configured height, diff panes split full width", function()


### PR DESCRIPTION
## Summary
Adds `explorer.position = "right"`, placing the file explorer on the right of the
diff view (`[ original | modified | explorer ]`).

Closes #430

## Changes
- `ui/layout.lua`: `arrange()` now pins **width** for `left`/`right` and **height** for `bottom` (was `left` vs. else).
- `config.lua` + `README.md`: document the new `"right"` value.
- `tests/ui/layout_spec.lua`: adds "Case 2b" verifying the right panel gets its configured width and diff panes stay equal.

## Testing
`layout_spec.lua` passes including the new case. `Split` already supported `right`; this teaches the layout manager to size it as a vertical panel.