### PR TITLE
fix: use absoute path for working tree single-revision diff

### DIFF
--- a/lua/codediff/commands.lua
+++ b/lua/codediff/commands.lua
@@ -91,6 +91,7 @@ local function handle_git_diff(revision, revision2, global_opts)
             end)
           end)
         else
+          local abs_path = vim.fn.fnamemodify(current_file, ":p")
           -- Compare revision vs working tree
           vim.schedule(function()
             ---@type SessionConfig
@@ -98,7 +99,7 @@ local function handle_git_diff(revision, revision2, global_opts)
               mode = "standalone",
               git_root = git_root,
               original_path = original_path,
-              modified_path = relative_path,
+              modified_path = abs_path,
               original_revision = commit_hash,
               modified_revision = "WORKING",
               layout = global_opts.layout,


### PR DESCRIPTION
When `:CodeDiff file HEAD` is run on a buffer whose path is outside the current working directory, `handle_git_diff` stored the file path relative to git root as `modified_path`.  Later `prepare_buffer` issued `:edit <relative_path>`, which Neovim resolves against cwd — not git root — causing the file to not be found.

Use `vim.fn.fnamemodify(current_file, ":p")` to always pass an absolute path when `modified_revision` is "WORKING" (real file), so `:edit` can locate the file regardless of cwd.