### PR TITLE
feat(ui): add per-pane window options callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ https://github.com/user-attachments/assets/64c41f01-dffe-4318-bce4-16eec8de356e
     -- Diff view behavior
     diff = {
       layout = "side-by-side",             -- Diff layout: "side-by-side" (two panes) or "inline" (single pane with virtual lines)
+      window_options = nil,                 -- Optional callback returning window-local options for diff panes
       disable_inlay_hints = true,         -- Disable inlay hints in diff windows for cleaner view
       max_computation_time_ms = 5000,     -- Maximum time for diff computation (VSCode default)
       ignore_trim_whitespace = false,     -- Ignore leading/trailing whitespace changes (like diffopt+=iwhite)
@@ -219,6 +220,33 @@ https://github.com/user-attachments/assets/64c41f01-dffe-4318-bce4-16eec8de356e
   },
 }
 ```
+
+### Diff Pane Window Options
+
+Use `diff.window_options` to return native window-local options for each real diff pane:
+
+```lua
+require("codediff").setup({
+  diff = {
+    window_options = function(ctx)
+      if ctx.role == "result" then
+        return { signcolumn = "yes:1" }
+      end
+      return { signcolumn = "no" }
+    end,
+  },
+})
+```
+
+The setting accepts a callback only, not a static options table. The callback receives:
+
+- `ctx.win`, `ctx.buf`, and `ctx.tabpage`: Neovim window, buffer, and tabpage IDs.
+- `ctx.role`: `"original"`, `"modified"`, `"result"`, or `"inline"`.
+- `ctx.view`: `"side-by-side"`, `"inline"`, or `"conflict"`.
+
+It runs only for panes displaying diff content. Explorer, history, welcome, placeholder, and non-CodeDiff windows are excluded. It is re-evaluated after pane creation, file selection, role or layout changes, conflict-result creation, and lifecycle events that may reset window options. Because it can run repeatedly, keep it idempotent and free of side effects. Return a table of window-local options, or `nil`/an empty table for no overrides. Options omitted by a later invocation are restored, and overrides are restored if CodeDiff releases a surviving window.
+
+The callback is a power-user escape hatch. Overriding CodeDiff-managed options such as `wrap`, `scrollbind`, or `winbar` can break alignment, synchronized scrolling, or conflict UI. Different `signcolumn` widths across side-by-side panes can also produce unequal text viewports. Invalid callback results and invalid options are reported and skipped. In particular, `signcolumn = "no"` hides every sign in that pane, including diagnostics, gitsigns, DAP signs, and CodeDiff's own move and conflict signs.
 
 The C library will be downloaded automatically on first use. No `build` step needed!
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ https://github.com/user-attachments/assets/64c41f01-dffe-4318-bce4-16eec8de356e
     -- Diff view behavior
     diff = {
       layout = "side-by-side",             -- Diff layout: "side-by-side" (two panes) or "inline" (single pane with virtual lines)
-      window_options = nil,                 -- Optional callback returning window-local options for diff panes
+      window_options = nil,               -- Optional callback returning window-local options for diff panes
       disable_inlay_hints = true,         -- Disable inlay hints in diff windows for cleaner view
       max_computation_time_ms = 5000,     -- Maximum time for diff computation (VSCode default)
       ignore_trim_whitespace = false,     -- Ignore leading/trailing whitespace changes (like diffopt+=iwhite)

--- a/doc/codediff.txt
+++ b/doc/codediff.txt
@@ -130,6 +130,50 @@ Set the layout in your config:
   })
 <
 
+                                              *codediff-window-options*
+Diff pane window options~
+
+Use `diff.window_options` to return native window-local options for each real
+pane displaying diff content:
+>lua
+  require("codediff").setup({
+    diff = {
+      window_options = function(ctx)
+        if ctx.role == "result" then
+          return { signcolumn = "yes:1" }
+        end
+        return { signcolumn = "no" }
+      end,
+    },
+  })
+<
+
+The setting accepts a callback only, not a static options table. It receives:
+
+  ctx.win       Neovim window ID
+  ctx.buf       Neovim buffer ID
+  ctx.tabpage   Neovim tabpage ID
+  ctx.role      "original", "modified", "result", or "inline"
+  ctx.view      "side-by-side", "inline", or "conflict"
+
+The callback runs only for real diff panes. Explorer, history, welcome,
+placeholder, and non-CodeDiff windows are excluded. It is re-evaluated after
+pane creation, file selection, role or layout changes, conflict-result
+creation, and lifecycle events that may reset window options. It may therefore
+run repeatedly and must be idempotent and free of side effects.
+
+Return a table of window-local options, or nil/an empty table for no overrides.
+Options omitted by a later invocation are restored. Overrides are also
+restored if CodeDiff releases a surviving window. Invalid callback results and
+invalid options are reported and skipped.
+
+This is a power-user escape hatch. Overriding CodeDiff-managed options such as
+`wrap`, `scrollbind`, or `winbar` can break alignment, synchronized scrolling,
+or conflict UI. Different `signcolumn` widths across side-by-side panes can
+also produce unequal text viewports. `signcolumn = "no"` hides every sign in
+that pane, including diagnostics, gitsigns, DAP signs, and CodeDiff move and
+conflict signs.
+
                                                       *codediff-moved-code*
 Moved code detection~
 
@@ -186,6 +230,7 @@ Setup entry point:
     },
     diff = {
       layout = "side-by-side",
+      window_options = nil,
       disable_inlay_hints = true,
       max_computation_time_ms = 5000,
       hide_merge_artifacts = false,

--- a/doc/tags
+++ b/doc/tags
@@ -15,5 +15,6 @@ codediff-quickstart	codediff.txt	/*codediff-quickstart*
 codediff-see-also	codediff.txt	/*codediff-see-also*
 codediff-toggle-layout	codediff.txt	/*codediff-toggle-layout*
 codediff-usage	codediff.txt	/*codediff-usage*
+codediff-window-options	codediff.txt	/*codediff-window-options*
 codediff.nvim	codediff.txt	/*codediff.nvim*
 codediff.txt	codediff.txt	/*codediff.txt*

--- a/lua/codediff/config.lua
+++ b/lua/codediff/config.lua
@@ -30,6 +30,7 @@ M.defaults = {
   -- Diff view behavior
   diff = {
     layout = "side-by-side", -- Diff layout: "side-by-side" or "inline"
+    window_options = nil,
     disable_inlay_hints = true, -- Disable inlay hints in diff windows for cleaner view
     max_computation_time_ms = 5000, -- Maximum time for diff computation (5 seconds, VSCode default)
     ignore_trim_whitespace = false, -- Ignore leading/trailing whitespace changes (like diffopt+=iwhite)
@@ -167,6 +168,11 @@ M.defaults = {
 M.options = vim.deepcopy(M.defaults)
 
 function M.setup(opts)
+  local window_options = opts and opts.diff and opts.diff.window_options
+  if window_options ~= nil and type(window_options) ~= "function" then
+    error("codediff: diff.window_options must be a function")
+  end
+
   M.options = vim.tbl_deep_extend("force", M.options, opts or {})
 end
 

--- a/lua/codediff/ui/lifecycle/cleanup.lua
+++ b/lua/codediff/ui/lifecycle/cleanup.lua
@@ -5,6 +5,7 @@ local accessors = require("codediff.ui.lifecycle.accessors")
 local session = require("codediff.ui.lifecycle.session")
 local state = require("codediff.ui.lifecycle.state")
 local welcome_window = require("codediff.ui.view.welcome_window")
+local window_options = require("codediff.ui.view.window_options")
 local compat = require("codediff.core.compat")
 
 -- Autocmd group for cleanup
@@ -91,6 +92,8 @@ local function cleanup_diff(tabpage)
       pcall(vim.api.nvim_buf_delete, diff.modified_bufnr, { force = true })
     end
   end
+
+  window_options.restore_session(diff)
 
   -- Clear window variables if windows still exist
   if diff.original_win and vim.api.nvim_win_is_valid(diff.original_win) then

--- a/lua/codediff/ui/lifecycle/session.lua
+++ b/lua/codediff/ui/lifecycle/session.lua
@@ -167,7 +167,7 @@ function M.create_session(
         return
       end
       local win = vim.api.nvim_get_current_win()
-      if win == sess.original_win or win == sess.modified_win then
+      if win == sess.original_win or win == sess.modified_win or win == sess.result_win then
         sync_window_ui(sess, win)
         -- Re-apply critical window options that might get reset by ftplugins/autocmds
         vim.wo[win].wrap = false

--- a/lua/codediff/ui/lifecycle/state.lua
+++ b/lua/codediff/ui/lifecycle/state.lua
@@ -3,6 +3,7 @@
 local M = {}
 
 local highlights = require("codediff.ui.highlights")
+local window_options = require("codediff.ui.view.window_options")
 
 -- Save buffer state before modifications
 local function save_buffer_state(bufnr)
@@ -258,6 +259,8 @@ local function resume_diff(tabpage)
   if diff.result_bufnr and vim.api.nvim_buf_is_valid(diff.result_bufnr) and diff.result_base_lines then
     auto_refresh.enable_for_result(diff.result_bufnr)
   end
+
+  window_options.apply_session(diff)
 
   -- Mark as active
   diff.suspended = false

--- a/lua/codediff/ui/view/conflict_window.lua
+++ b/lua/codediff/ui/view/conflict_window.lua
@@ -5,6 +5,7 @@ local lifecycle = require("codediff.ui.lifecycle")
 local auto_refresh = require("codediff.ui.auto_refresh")
 local config = require("codediff.config")
 local layout = require("codediff.ui.layout")
+local window_options = require("codediff.ui.view.window_options")
 
 --- Create result window at the bottom (default layout)
 --- Layout: [incoming | current] on top, [result] at bottom
@@ -162,6 +163,7 @@ function M.setup_conflict_result_window(tabpage, session_config, original_win, m
   local session = lifecycle.get_session(tabpage)
   if session then
     conflict.refresh_all_conflict_signs(session)
+    window_options.apply_session(session)
   end
 
   -- Return focus to modified window

--- a/lua/codediff/ui/view/inline_view.lua
+++ b/lua/codediff/ui/view/inline_view.lua
@@ -10,6 +10,7 @@ local inline = require("codediff.ui.inline")
 local semantic = require("codediff.ui.semantic_tokens")
 local layout = require("codediff.ui.layout")
 local welcome_window = require("codediff.ui.view.welcome_window")
+local window_options = require("codediff.ui.view.window_options")
 
 local helpers = require("codediff.ui.view.helpers")
 local panel = require("codediff.ui.view.panel")
@@ -248,6 +249,7 @@ function M.create(session_config, filetype, on_ready)
       )
 
       mark_inline(tabpage)
+      window_options.apply_session(lifecycle.get_session(tabpage))
 
       auto_refresh.enable(original_info.bufnr)
       auto_refresh.enable(modified_info.bufnr)
@@ -419,6 +421,7 @@ function M.update(tabpage, session_config, auto_scroll_to_first_hunk)
 
       setup_keymaps(tabpage, orig_buf, mod_buf)
       layout.arrange(tabpage)
+      window_options.apply_session(session)
 
       if saved_current_win and vim.api.nvim_win_is_valid(saved_current_win) then
         vim.api.nvim_set_current_win(saved_current_win)
@@ -600,6 +603,7 @@ function M.show_single_file(tabpage, file_path, opts)
   local view_keymaps = require("codediff.ui.view.keymaps")
   view_keymaps.setup_all_keymaps(tabpage, orig_bufnr, mod_bufnr, session.mode == "explorer")
   layout.arrange(tabpage)
+  window_options.apply_session(session)
   welcome_window.sync_later(mod_win)
 end
 

--- a/lua/codediff/ui/view/side_by_side.lua
+++ b/lua/codediff/ui/view/side_by_side.lua
@@ -19,6 +19,7 @@ local view_keymaps = require("codediff.ui.view.keymaps")
 local conflict_window = require("codediff.ui.view.conflict_window")
 local panel = require("codediff.ui.view.panel")
 local welcome_window = require("codediff.ui.view.welcome_window")
+local window_options = require("codediff.ui.view.window_options")
 
 local is_virtual_revision = helpers.is_virtual_revision
 local prepare_buffer = helpers.prepare_buffer
@@ -290,6 +291,7 @@ function M.create(session_config, filetype, on_ready)
               setup_all_keymaps(tabpage, ob, mb, is_explorer)
             end
           )
+          window_options.apply_session(lifecycle.get_session(tabpage))
           -- Enable auto-refresh for real file buffers only
           setup_auto_refresh(original_info.bufnr, modified_info.bufnr, original_is_virtual, modified_is_virtual)
 
@@ -539,6 +541,7 @@ function M.update(tabpage, session_config, auto_scroll_to_first_hunk)
         lifecycle.update_revisions(tabpage, session_config.original_revision, session_config.modified_revision)
         lifecycle.update_diff_result(tabpage, lines_diff)
         lifecycle.update_changedtick(tabpage, vim.api.nvim_buf_get_changedtick(original_info.bufnr), vim.api.nvim_buf_get_changedtick(modified_info.bufnr))
+        window_options.apply_session(session)
         setup_auto_refresh(original_info.bufnr, modified_info.bufnr, original_is_virtual, modified_is_virtual)
 
         local is_explorer_mode = session.mode == "explorer"
@@ -770,6 +773,7 @@ local function show_single_file(tabpage, opts)
   end
 
   layout.arrange(tabpage)
+  window_options.apply_session(session)
   if keep_win and vim.api.nvim_win_is_valid(keep_win) then
     welcome_window.sync_later(keep_win)
   end

--- a/lua/codediff/ui/view/welcome_window.lua
+++ b/lua/codediff/ui/view/welcome_window.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local welcome = require("codediff.ui.welcome")
+local window_options = require("codediff.ui.view.window_options")
 
 local option_names = {
   "number",
@@ -44,6 +45,9 @@ local function get_session_for_window(winid)
     end
     if sess.modified_win == winid then
       return sess, "modified"
+    end
+    if sess.result_win == winid then
+      return sess, "result"
     end
   end
   return nil, nil
@@ -97,9 +101,12 @@ function M.sync(winid)
 
   local bufnr = vim.api.nvim_win_get_buf(winid)
   if welcome.is_welcome_buffer(bufnr) then
+    window_options.restore(winid)
     M.apply(winid)
   else
     M.apply_normal(winid)
+    local sess = get_session_for_window(winid)
+    window_options.apply_window(sess, winid)
   end
 end
 

--- a/lua/codediff/ui/view/window_options.lua
+++ b/lua/codediff/ui/view/window_options.lua
@@ -1,0 +1,191 @@
+local M = {}
+
+local config = require("codediff.config")
+local welcome = require("codediff.ui.welcome")
+
+local restore_variable = "codediff_window_options_restore"
+
+local function notify_error(message)
+  vim.notify("[codediff] diff.window_options " .. message, vim.log.levels.ERROR)
+end
+
+local function is_valid_window(win)
+  return win and vim.api.nvim_win_is_valid(win)
+end
+
+local function set_window_option(win, name, value)
+  return pcall(function()
+    vim.wo[win][name] = value
+  end)
+end
+
+function M.restore(win)
+  if not is_valid_window(win) then
+    return
+  end
+
+  local restore = vim.w[win][restore_variable]
+  if type(restore) ~= "table" then
+    return
+  end
+
+  for name, value in pairs(restore) do
+    set_window_option(win, name, value)
+  end
+  vim.w[win][restore_variable] = nil
+end
+
+local function evaluate(callback, context)
+  local ok, options = pcall(callback, context)
+  if not ok then
+    notify_error("callback failed: " .. tostring(options))
+    return nil
+  end
+  if options ~= nil and type(options) ~= "table" then
+    notify_error("must return a table or nil")
+    return nil
+  end
+  return options or {}
+end
+
+local function restore_omitted_options(win, restore, options)
+  local retained = {}
+  for name, value in pairs(restore) do
+    if options[name] == nil then
+      set_window_option(win, name, value)
+    else
+      retained[name] = value
+    end
+  end
+  return retained
+end
+
+local function apply_option(win, restore, name, value)
+  if type(name) ~= "string" then
+    notify_error("returned a non-string option name")
+    return
+  end
+
+  local ok, current = pcall(function()
+    return vim.wo[win][name]
+  end)
+  if not ok then
+    notify_error("returned an invalid window option: " .. name)
+    return
+  end
+
+  if restore[name] == nil then
+    restore[name] = current
+  end
+
+  local applied, err = set_window_option(win, name, value)
+  if applied then
+    return
+  end
+
+  notify_error("could not set " .. name .. ": " .. tostring(err))
+  set_window_option(win, name, restore[name])
+  restore[name] = nil
+end
+
+function M.apply(win, role, view)
+  if not is_valid_window(win) then
+    return
+  end
+
+  local bufnr = vim.api.nvim_win_get_buf(win)
+  if welcome.is_welcome_buffer(bufnr) then
+    M.restore(win)
+    return
+  end
+
+  local callback = config.options.diff.window_options
+  if not callback then
+    M.restore(win)
+    return
+  end
+
+  local options = evaluate(callback, {
+    win = win,
+    buf = bufnr,
+    tabpage = vim.api.nvim_win_get_tabpage(win),
+    role = role,
+    view = view,
+  })
+  if not options then
+    M.restore(win)
+    return
+  end
+
+  local restore = vim.w[win][restore_variable]
+  if type(restore) ~= "table" then
+    restore = {}
+  end
+
+  restore = restore_omitted_options(win, restore, options)
+  for name, value in pairs(options) do
+    apply_option(win, restore, name, value)
+  end
+
+  vim.w[win][restore_variable] = next(restore) and restore or nil
+end
+
+local function get_view(session)
+  if session.result_win and is_valid_window(session.result_win) then
+    return "conflict"
+  end
+  return session.layout == "inline" and "inline" or "side-by-side"
+end
+
+function M.apply_window(session, win)
+  if not session or not is_valid_window(win) then
+    return
+  end
+  if not session.result_win and session.original_path == "" and session.modified_path == "" then
+    M.restore(win)
+    return
+  end
+
+  local view = get_view(session)
+  if view == "inline" and (win == session.original_win or win == session.modified_win) then
+    M.apply(win, "inline", view)
+  elseif win == session.result_win then
+    M.apply(win, "result", view)
+  elseif win == session.original_win then
+    M.apply(win, "original", view)
+  elseif win == session.modified_win then
+    M.apply(win, "modified", view)
+  end
+end
+
+function M.apply_session(session)
+  if not session then
+    return
+  end
+
+  local seen = {}
+  for _, field in ipairs({ "original_win", "modified_win", "result_win" }) do
+    local win = session[field]
+    if is_valid_window(win) and not seen[win] then
+      M.apply_window(session, win)
+      seen[win] = true
+    end
+  end
+end
+
+function M.restore_session(session)
+  if not session then
+    return
+  end
+
+  local seen = {}
+  for _, field in ipairs({ "original_win", "modified_win", "result_win" }) do
+    local win = session[field]
+    if is_valid_window(win) and not seen[win] then
+      M.restore(win)
+      seen[win] = true
+    end
+  end
+end
+
+return M

--- a/tests/ui/view/window_options_spec.lua
+++ b/tests/ui/view/window_options_spec.lua
@@ -1,0 +1,250 @@
+local config = require("codediff.config")
+local welcome = require("codediff.ui.welcome")
+local window_options = require("codediff.ui.view.window_options")
+
+local function create_window()
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  vim.cmd("vsplit")
+  local win = vim.api.nvim_get_current_win()
+  vim.api.nvim_win_set_buf(win, bufnr)
+  return win, bufnr
+end
+
+local function close_extra_windows()
+  local current = vim.api.nvim_get_current_win()
+  for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+    if win ~= current and vim.api.nvim_win_is_valid(win) then
+      vim.api.nvim_win_close(win, true)
+    end
+  end
+end
+
+describe("Diff window options", function()
+  before_each(function()
+    config.options.diff.window_options = nil
+  end)
+
+  after_each(function()
+    for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+      window_options.restore(win)
+    end
+    config.options.diff.window_options = nil
+    if welcome.is_welcome_buffer(vim.api.nvim_get_current_buf()) then
+      vim.cmd("enew")
+    end
+    close_extra_windows()
+  end)
+
+  it("rejects static window option tables", function()
+    assert.has_error(function()
+      config.setup({ diff = { window_options = { signcolumn = "no" } } })
+    end, "codediff: diff.window_options must be a function")
+  end)
+
+  it("applies returned options and provides the pane context", function()
+    local win = vim.api.nvim_get_current_win()
+    local original_signcolumn = vim.wo[win].signcolumn
+    local context
+    config.options.diff.window_options = function(ctx)
+      context = ctx
+      return { signcolumn = "no", number = false }
+    end
+
+    window_options.apply(win, "original", "side-by-side")
+
+    assert.equals(win, context.win)
+    assert.equals(vim.api.nvim_win_get_buf(win), context.buf)
+    assert.equals(vim.api.nvim_get_current_tabpage(), context.tabpage)
+    assert.equals("original", context.role)
+    assert.equals("side-by-side", context.view)
+    assert.equals("no", vim.wo[win].signcolumn)
+    assert.is_false(vim.wo[win].number)
+
+    window_options.restore(win)
+    assert.equals(original_signcolumn, vim.wo[win].signcolumn)
+  end)
+
+  it("restores options omitted after a role change", function()
+    local win = vim.api.nvim_get_current_win()
+    local original_signcolumn = vim.wo[win].signcolumn
+    config.options.diff.window_options = function(ctx)
+      if ctx.role == "original" then
+        return { signcolumn = "no" }
+      end
+      return {}
+    end
+
+    window_options.apply(win, "original", "side-by-side")
+    assert.equals("no", vim.wo[win].signcolumn)
+
+    window_options.apply(win, "result", "conflict")
+    assert.equals(original_signcolumn, vim.wo[win].signcolumn)
+  end)
+
+  it("reports invalid option values and restores the previous value", function()
+    local win = vim.api.nvim_get_current_win()
+    local original_signcolumn = vim.wo[win].signcolumn
+    local value = "no"
+    local notifications = {}
+    local original_notify = vim.notify
+    vim.notify = function(message)
+      table.insert(notifications, message)
+    end
+
+    local ok, err = pcall(function()
+      config.options.diff.window_options = function()
+        return { signcolumn = value }
+      end
+      window_options.apply(win, "original", "side-by-side")
+      value = "invalid"
+      window_options.apply(win, "original", "side-by-side")
+    end)
+    vim.notify = original_notify
+
+    assert.is_true(ok, err)
+    assert.equals(original_signcolumn, vim.wo[win].signcolumn)
+    assert.is_true(#notifications > 0)
+  end)
+
+  it("assigns side-by-side, inline, and conflict roles", function()
+    local original_win = vim.api.nvim_get_current_win()
+    local modified_win = create_window()
+    local seen = {}
+    config.options.diff.window_options = function(ctx)
+      seen[ctx.role] = ctx.view
+      return { signcolumn = "no" }
+    end
+
+    local session = {
+      original_path = "old.lua",
+      modified_path = "new.lua",
+      original_win = original_win,
+      modified_win = modified_win,
+      layout = "side-by-side",
+    }
+    window_options.apply_session(session)
+    assert.equals("side-by-side", seen.original)
+    assert.equals("side-by-side", seen.modified)
+
+    seen = {}
+    session.original_win = modified_win
+    session.layout = "inline"
+    window_options.apply_session(session)
+    assert.equals("inline", seen.inline)
+    assert.is_nil(seen.original)
+    assert.is_nil(seen.modified)
+
+    local result_win = create_window()
+    seen = {}
+    session.original_win = original_win
+    session.modified_win = modified_win
+    session.result_win = result_win
+    session.layout = "side-by-side"
+    window_options.apply_session(session)
+    assert.equals("conflict", seen.original)
+    assert.equals("conflict", seen.modified)
+    assert.equals("conflict", seen.result)
+  end)
+
+  it("does not invoke the callback for placeholder or welcome panes", function()
+    local win = vim.api.nvim_get_current_win()
+    local calls = 0
+    config.options.diff.window_options = function()
+      calls = calls + 1
+      return { signcolumn = "yes:1" }
+    end
+
+    window_options.apply_session({
+      original_path = "",
+      modified_path = "",
+      original_win = win,
+      modified_win = win,
+      layout = "inline",
+    })
+    assert.equals(0, calls)
+
+    local welcome_buf = welcome.create_buffer(80, 24)
+    vim.api.nvim_win_set_buf(win, welcome_buf)
+    window_options.apply(win, "inline", "inline")
+    assert.equals(0, calls)
+  end)
+end)
+
+describe("Diff window options integration", function()
+  local paths = {}
+
+  before_each(function()
+    paths = { vim.fn.tempname() .. ".lua", vim.fn.tempname() .. ".lua" }
+    vim.fn.writefile({ "local value = 1" }, paths[1])
+    vim.fn.writefile({ "local value = 2" }, paths[2])
+  end)
+
+  after_each(function()
+    config.options.diff.window_options = nil
+    while vim.fn.tabpagenr("$") > 1 do
+      vim.cmd("tabclose!")
+    end
+    for _, path in ipairs(paths) do
+      vim.fn.delete(path)
+    end
+  end)
+
+  it("reapplies role-specific options across layout changes", function()
+    local seen = {}
+    require("codediff").setup({
+      diff = {
+        layout = "side-by-side",
+        window_options = function(ctx)
+          seen[ctx.role] = (seen[ctx.role] or 0) + 1
+          local values = {
+            original = "no",
+            modified = "yes:1",
+            inline = "yes:2",
+          }
+          return { signcolumn = values[ctx.role] or "auto" }
+        end,
+      },
+    })
+
+    local ready = false
+    require("codediff.ui.view").create(
+      {
+        mode = "standalone",
+        original_path = paths[1],
+        modified_path = paths[2],
+      },
+      nil,
+      function()
+        ready = true
+      end
+    )
+
+    assert.is_true(vim.wait(5000, function()
+      return ready
+    end, 20))
+
+    local tabpage = vim.api.nvim_get_current_tabpage()
+    local lifecycle = require("codediff.ui.lifecycle")
+    local session = lifecycle.get_session(tabpage)
+    assert.equals("no", vim.wo[session.original_win].signcolumn)
+    assert.equals("yes:1", vim.wo[session.modified_win].signcolumn)
+    assert.is_true(seen.original > 0)
+    assert.is_true(seen.modified > 0)
+
+    assert.is_true(require("codediff.ui.view").toggle_layout(tabpage))
+    assert.is_true(vim.wait(5000, function()
+      session = lifecycle.get_session(tabpage)
+      return session and session.layout == "inline" and seen.inline and vim.wo[session.modified_win].signcolumn == "yes:2"
+    end, 20))
+
+    assert.is_true(require("codediff.ui.view").toggle_layout(tabpage))
+    assert.is_true(vim.wait(5000, function()
+      session = lifecycle.get_session(tabpage)
+      return session
+        and session.layout == "side-by-side"
+        and session.original_win ~= session.modified_win
+        and vim.wo[session.original_win].signcolumn == "no"
+        and vim.wo[session.modified_win].signcolumn == "yes:1"
+    end, 20))
+  end)
+end)


### PR DESCRIPTION
Add `diff.window_options(ctx)`, allowing users to return native window-local options for CodeDiff content panes.

The callback exposes:

- Roles: `original`, `modified`, `result`, and `inline`
- Views: `side-by-side`, `inline`, and `conflict`
- Window, buffer, and tabpage IDs

Options are reapplied across file selections, layout changes, conflict creation, and lifecycle events. Previous values are restored when omitted or when CodeDiff releases a surviving window.

Explorer, history, welcome, placeholder, and non-CodeDiff windows are unaffected.

Documentation notes that overriding CodeDiff-managed options may break layout behavior and that `signcolumn = "no"` hides all signs, including CodeDiff move and conflict signs.
