### PR TITLE
feat: add configurable line pairing for intraline highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,92 @@ https://github.com/user-attachments/assets/64c41f01-dffe-4318-bce4-16eec8de356e
 }
 ```
 
+### Intraline line matching
+
+CodeDiff uses a callback to pair original and modified lines within each changed block. Paired lines use `CodeDiffLineDelete`/`CodeDiffLineInsert`, with changed text additionally using `CodeDiffCharDelete`/`CodeDiffCharInsert`. Unpaired lines use only `CodeDiffLineDelete` or `CodeDiffLineInsert`. Similarity matching with a `0.75` threshold is the default:
+
+```lua
+local line_matchers = require("codediff.line_matchers")
+
+require("codediff").setup({
+  diff = {
+    line_matcher = line_matchers.similarity,
+  },
+})
+```
+
+Wrap the default matcher to choose a threshold from `0.0` to `1.0`; lower values pair more lines:
+
+```lua
+require("codediff").setup({
+  diff = {
+    line_matcher = function(context)
+      return line_matchers.similarity(context, {
+        threshold = 0.6,
+      })
+    end,
+  },
+})
+```
+
+For GitHub-style matching, pair lines by position only when both sides of a changed block have the same line count:
+
+```lua
+require("codediff").setup({
+  diff = {
+    line_matcher = line_matchers.equal_line_count,
+  },
+})
+```
+
+To disable character-level matching while retaining line-level highlights:
+
+```lua
+require("codediff").setup({
+  diff = {
+    line_matcher = line_matchers.none,
+  },
+})
+```
+
+Custom callbacks receive one changed block and return ordered, non-crossing pairs of 1-based indices:
+
+```lua
+---@class CodeDiffLineMatcherContext
+---@field original_lines string[]
+---@field modified_lines string[]
+---@field original_start_line integer
+---@field modified_start_line integer
+
+---@class CodeDiffLinePair
+---@field original_index integer
+---@field modified_index integer
+
+---@alias CodeDiffLineMatcher fun(context: CodeDiffLineMatcherContext): CodeDiffLinePair[]
+```
+
+For example:
+
+```lua
+local function match_by_position(context)
+  local pair_count = math.min(#context.original_lines, #context.modified_lines)
+  local pairs = {}
+
+  for index = 1, pair_count do
+    pairs[index] = {
+      original_index = index,
+      modified_index = index,
+    }
+  end
+
+  return pairs
+end
+```
+
+Each line may appear in at most one pair. Omitted lines remain unpaired. Paired lines retain `CodeDiffLineInsert` or `CodeDiffLineDelete` and receive `CodeDiffCharInsert` or `CodeDiffCharDelete` over changed characters. Unpaired lines receive only their line-level highlight. Pure insertions and deletions do not invoke the matcher.
+
+Matchers run synchronously during rendering and automatic refreshes. Custom callbacks should avoid I/O and return quickly. `diff.max_computation_time_ms` cannot interrupt custom Lua code.
+
 The C library will be downloaded automatically on first use. No `build` step needed!
 
 ### Managing Library Installation

--- a/README.md
+++ b/README.md
@@ -268,6 +268,16 @@ require("codediff").setup({
 })
 ```
 
+For VS Code-style matching, refine whole changed blocks, including splits and merges:
+
+```lua
+require("codediff").setup({
+  diff = {
+    line_matcher = line_matchers.vscode,
+  },
+})
+```
+
 Custom callbacks receive one changed block and return ordered, non-overlapping line range mappings. Indices are 1-based within the callback arrays and end indices are exclusive:
 
 ```lua

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ https://github.com/user-attachments/assets/64c41f01-dffe-4318-bce4-16eec8de356e
 
 ### Intraline line matching
 
-CodeDiff uses a callback to pair original and modified lines within each changed block. Paired lines use `CodeDiffLineDelete`/`CodeDiffLineInsert`, with changed text additionally using `CodeDiffCharDelete`/`CodeDiffCharInsert`. Unpaired lines use only `CodeDiffLineDelete` or `CodeDiffLineInsert`. Similarity matching with a `0.75` threshold is the default:
+CodeDiff uses a callback to map original and modified line ranges within each changed block. Mapped ranges use `CodeDiffLineDelete`/`CodeDiffLineInsert`, with changed text additionally using `CodeDiffCharDelete`/`CodeDiffCharInsert`. Unmapped lines use only `CodeDiffLineDelete` or `CodeDiffLineInsert`. Similarity matching with a `0.75` threshold is the default:
 
 ```lua
 local line_matchers = require("codediff.line_matchers")
@@ -268,7 +268,7 @@ require("codediff").setup({
 })
 ```
 
-Custom callbacks receive one changed block and return ordered, non-crossing pairs of 1-based indices:
+Custom callbacks receive one changed block and return ordered, non-overlapping line range mappings. Indices are 1-based within the callback arrays and end indices are exclusive:
 
 ```lua
 ---@class CodeDiffLineMatcherContext
@@ -277,32 +277,36 @@ Custom callbacks receive one changed block and return ordered, non-crossing pair
 ---@field original_start_line integer
 ---@field modified_start_line integer
 
----@class CodeDiffLinePair
----@field original_index integer
----@field modified_index integer
+---@class CodeDiffLineRange
+---@field start_index integer
+---@field end_index integer
 
----@alias CodeDiffLineMatcher fun(context: CodeDiffLineMatcherContext): CodeDiffLinePair[]
+---@class CodeDiffLineRangeMapping
+---@field original CodeDiffLineRange
+---@field modified CodeDiffLineRange
+
+---@alias CodeDiffLineMatcher fun(context: CodeDiffLineMatcherContext): CodeDiffLineRangeMapping[]
 ```
 
 For example:
 
 ```lua
 local function match_by_position(context)
-  local pair_count = math.min(#context.original_lines, #context.modified_lines)
-  local pairs = {}
+  local mapping_count = math.min(#context.original_lines, #context.modified_lines)
+  local mappings = {}
 
-  for index = 1, pair_count do
-    pairs[index] = {
-      original_index = index,
-      modified_index = index,
+  for index = 1, mapping_count do
+    mappings[index] = {
+      original = { start_index = index, end_index = index + 1 },
+      modified = { start_index = index, end_index = index + 1 },
     }
   end
 
-  return pairs
+  return mappings
 end
 ```
 
-Each line may appear in at most one pair. Omitted lines remain unpaired. Paired lines retain `CodeDiffLineInsert` or `CodeDiffLineDelete` and receive `CodeDiffCharInsert` or `CodeDiffCharDelete` over changed characters. Unpaired lines receive only their line-level highlight. Pure insertions and deletions do not invoke the matcher.
+Mappings may be one-to-one, one-to-many, or many-to-one. Either side may be empty for a pure insertion or deletion, but both sides cannot be empty. Omitted lines remain unmapped and receive only their line-level highlight. Mapped ranges retain `CodeDiffLineInsert` or `CodeDiffLineDelete` and receive `CodeDiffCharInsert` or `CodeDiffCharDelete` over changed characters.
 
 Matchers run synchronously during rendering and automatic refreshes. Custom callbacks should avoid I/O and return quickly. `diff.max_computation_time_ms` cannot interrupt custom Lua code.
 

--- a/doc/codediff.txt
+++ b/doc/codediff.txt
@@ -133,10 +133,10 @@ Set the layout in your config:
                                               *codediff-line-matching*
 Intraline line matching~
 
-CodeDiff uses a callback to pair original and modified lines within each
-changed block. Paired lines use CodeDiffLineDelete/CodeDiffLineInsert, with
+CodeDiff uses a callback to map original and modified line ranges within each
+changed block. Mapped ranges use CodeDiffLineDelete/CodeDiffLineInsert, with
 changed text additionally using CodeDiffCharDelete/CodeDiffCharInsert.
-Unpaired lines use only CodeDiffLineDelete or CodeDiffLineInsert. Similarity
+Unmapped lines use only CodeDiffLineDelete or CodeDiffLineInsert. Similarity
 matching with a 0.75 threshold is the default:
 >lua
   local line_matchers = require("codediff.line_matchers")
@@ -164,16 +164,25 @@ Other built-ins:
 <
 
 A custom matcher receives `original_lines`, `modified_lines`,
-`original_start_line`, and `modified_start_line`. It returns ordered pairs:
+`original_start_line`, and `modified_start_line`. It returns ordered,
+non-overlapping line range mappings:
 >lua
   return {
-    { original_index = 1, modified_index = 1 },
-    { original_index = 3, modified_index = 2 },
+    {
+      original = { start_index = 1, end_index = 2 },
+      modified = { start_index = 1, end_index = 2 },
+    },
+    {
+      original = { start_index = 3, end_index = 4 },
+      modified = { start_index = 2, end_index = 3 },
+    },
   }
 <
 
-Indices are 1-based within the callback's line arrays. Paired lines receive
-line-level and changed-character highlights. Unpaired lines receive only
+Indices are 1-based within the callback's line arrays and end indices are
+exclusive. Mappings may be one-to-one, one-to-many, or many-to-one. Either
+side may be empty, but both sides cannot be empty. Mapped ranges receive
+line-level and changed-character highlights. Unmapped lines receive only
 line-level highlights.
 
                                                       *codediff-moved-code*

--- a/doc/codediff.txt
+++ b/doc/codediff.txt
@@ -161,6 +161,7 @@ Other built-ins:
 >lua
   line_matchers.equal_line_count  -- GitHub-style: pair positionally only for equal counts
   line_matchers.none              -- Disable character-level matching
+  line_matchers.vscode            -- VS Code-style: refine whole blocks, including splits and merges
 <
 
 A custom matcher receives `original_lines`, `modified_lines`,

--- a/doc/codediff.txt
+++ b/doc/codediff.txt
@@ -130,6 +130,52 @@ Set the layout in your config:
   })
 <
 
+                                              *codediff-line-matching*
+Intraline line matching~
+
+CodeDiff uses a callback to pair original and modified lines within each
+changed block. Paired lines use CodeDiffLineDelete/CodeDiffLineInsert, with
+changed text additionally using CodeDiffCharDelete/CodeDiffCharInsert.
+Unpaired lines use only CodeDiffLineDelete or CodeDiffLineInsert. Similarity
+matching with a 0.75 threshold is the default:
+>lua
+  local line_matchers = require("codediff.line_matchers")
+
+  require("codediff").setup({
+    diff = { line_matcher = line_matchers.similarity },
+  })
+<
+
+Wrap the default matcher to change its threshold:
+>lua
+  require("codediff").setup({
+    diff = {
+      line_matcher = function(context)
+        return line_matchers.similarity(context, { threshold = 0.6 })
+      end,
+    },
+  })
+<
+
+Other built-ins:
+>lua
+  line_matchers.equal_line_count  -- GitHub-style: pair positionally only for equal counts
+  line_matchers.none              -- Disable character-level matching
+<
+
+A custom matcher receives `original_lines`, `modified_lines`,
+`original_start_line`, and `modified_start_line`. It returns ordered pairs:
+>lua
+  return {
+    { original_index = 1, modified_index = 1 },
+    { original_index = 3, modified_index = 2 },
+  }
+<
+
+Indices are 1-based within the callback's line arrays. Paired lines receive
+line-level and changed-character highlights. Unpaired lines receive only
+line-level highlights.
+
                                                       *codediff-moved-code*
 Moved code detection~
 
@@ -188,6 +234,7 @@ Setup entry point:
       layout = "side-by-side",
       disable_inlay_hints = true,
       max_computation_time_ms = 5000,
+      line_matcher = require("codediff.line_matchers").similarity,
       hide_merge_artifacts = false,
       conflict_result_position = "bottom",
       conflict_result_height = 30,

--- a/doc/tags
+++ b/doc/tags
@@ -9,6 +9,7 @@ codediff-highlight-groups	codediff.txt	/*codediff-highlight-groups*
 codediff-history	codediff.txt	/*codediff-history*
 codediff-history-line-range	codediff.txt	/*codediff-history-line-range*
 codediff-layout	codediff.txt	/*codediff-layout*
+codediff-line-matching	codediff.txt	/*codediff-line-matching*
 codediff-lua-api	codediff.txt	/*codediff-lua-api*
 codediff-moved-code	codediff.txt	/*codediff-moved-code*
 codediff-quickstart	codediff.txt	/*codediff-quickstart*

--- a/libvscode-diff/include/char_level.h
+++ b/libvscode-diff/include/char_level.h
@@ -62,6 +62,11 @@ RangeMappingArray *refine_diff_char_level(const SequenceDiff *line_diff, const c
                                           int len_a, const char **lines_b, int len_b,
                                           const CharLevelOptions *options, bool *out_hit_timeout);
 
+RangeMappingBatch *refine_diffs_char_level(const SequenceDiffArray *line_diffs,
+                                           const char **lines_a, int len_a, const char **lines_b,
+                                           int len_b, const CharLevelOptions *options,
+                                           bool *out_hit_timeout);
+
 /**
  * Refine all line-level diffs to character-level - VSCode Parity
  * 
@@ -90,5 +95,6 @@ RangeMappingArray *refine_all_diffs_char_level(const SequenceDiffArray *line_dif
  * Helper: Free RangeMappingArray
  */
 void free_range_mapping_array(RangeMappingArray *arr);
+void free_range_mapping_batch(RangeMappingBatch *batch);
 
 #endif // CHAR_LEVEL_H

--- a/libvscode-diff/include/types.h
+++ b/libvscode-diff/include/types.h
@@ -70,6 +70,11 @@ typedef struct {
   int capacity;
 } RangeMappingArray;
 
+typedef struct {
+  RangeMappingArray *results;
+  int count;
+} RangeMappingBatch;
+
 /**
  * DetailedLineRangeMapping - Final algorithm output
  * Maps to VSCode's DetailedLineRangeMapping.

--- a/libvscode-diff/libvscode_diff.def
+++ b/libvscode-diff/libvscode_diff.def
@@ -4,6 +4,8 @@ EXPORTS
     compute_line_alignments
     free_lines_diff
     free_range_mapping_array
+    free_range_mapping_batch
     free_sequence_diff_array
     refine_diff_char_level
+    refine_diffs_char_level
     get_version

--- a/libvscode-diff/libvscode_diff.def
+++ b/libvscode-diff/libvscode_diff.def
@@ -3,5 +3,7 @@ EXPORTS
     compute_diff
     compute_line_alignments
     free_lines_diff
+    free_range_mapping_array
     free_sequence_diff_array
+    refine_diff_char_level
     get_version

--- a/libvscode-diff/libvscode_diff.def
+++ b/libvscode-diff/libvscode_diff.def
@@ -1,5 +1,7 @@
 LIBRARY vscode_diff
 EXPORTS
     compute_diff
+    compute_line_alignments
     free_lines_diff
+    free_sequence_diff_array
     get_version

--- a/libvscode-diff/src/char_level.c
+++ b/libvscode-diff/src/char_level.c
@@ -900,56 +900,80 @@ RangeMappingArray *refine_diff_char_level(const SequenceDiff *line_diff, const c
   return result;
 }
 
+RangeMappingBatch *refine_diffs_char_level(const SequenceDiffArray *line_diffs,
+                                           const char **lines_a, int len_a, const char **lines_b,
+                                           int len_b, const CharLevelOptions *options,
+                                           bool *out_hit_timeout) {
+  if (out_hit_timeout) {
+    *out_hit_timeout = false;
+  }
+  if (!line_diffs || !lines_a || !lines_b || !options) {
+    return NULL;
+  }
+
+  RangeMappingBatch *batch = (RangeMappingBatch *)malloc(sizeof(RangeMappingBatch));
+  if (!batch) {
+    return NULL;
+  }
+  batch->count = line_diffs->count;
+  batch->results = line_diffs->count > 0 ? (RangeMappingArray *)calloc((size_t)line_diffs->count,
+                                                                       sizeof(RangeMappingArray))
+                                         : NULL;
+  if (line_diffs->count > 0 && !batch->results) {
+    free(batch);
+    return NULL;
+  }
+
+  bool any_timeout = false;
+  for (int i = 0; i < line_diffs->count; i++) {
+    bool local_timeout = false;
+    RangeMappingArray *mappings = refine_diff_char_level(&line_diffs->diffs[i], lines_a, len_a,
+                                                         lines_b, len_b, options, &local_timeout);
+    if (!mappings) {
+      free_range_mapping_batch(batch);
+      return NULL;
+    }
+    batch->results[i] = *mappings;
+    free(mappings);
+    any_timeout = any_timeout || local_timeout;
+  }
+
+  if (out_hit_timeout) {
+    *out_hit_timeout = any_timeout;
+  }
+  return batch;
+}
+
 /**
- * Refine all line-level diffs - VSCode Parity
+ * Refine all line-level diffs - To confirm lua implementation has VSCode Parity
  */
 RangeMappingArray *refine_all_diffs_char_level(const SequenceDiffArray *line_diffs,
                                                const char **lines_a, int len_a,
                                                const char **lines_b, int len_b,
                                                const CharLevelOptions *options,
                                                bool *out_hit_timeout) {
-  // Initialize timeout flag
-  if (out_hit_timeout) {
-    *out_hit_timeout = false;
-  }
-
-  if (!line_diffs || !lines_a || !lines_b || !options) {
+  RangeMappingBatch *batch =
+      refine_diffs_char_level(line_diffs, lines_a, len_a, lines_b, len_b, options, out_hit_timeout);
+  if (!batch) {
     return NULL;
   }
 
   RangeMappingArray *result =
       create_range_mapping_array(line_diffs->count > 0 ? line_diffs->count * 4 : 10);
-
-  // Track if any refinement hit timeout
-  bool any_timeout = false;
-
-  // Refine each line diff
-  for (int i = 0; i < line_diffs->count; i++) {
-    bool local_timeout = false;
-    RangeMappingArray *char_mappings = refine_diff_char_level(
-        &line_diffs->diffs[i], lines_a, len_a, lines_b, len_b, options, &local_timeout);
-
-    // Accumulate timeout status (VSCode: if (characterDiffs.hitTimeout) hitTimeout = true)
-    if (local_timeout) {
-      any_timeout = true;
-    }
-
-    if (char_mappings) {
-      for (int j = 0; j < char_mappings->count; j++) {
-        add_range_mapping(result, &char_mappings->mappings[j]);
+  if (!result) {
+    free_range_mapping_batch(batch);
+    return NULL;
+  }
+  for (int i = 0; i < batch->count; i++) {
+    for (int j = 0; j < batch->results[i].count; j++) {
+      if (!add_range_mapping(result, &batch->results[i].mappings[j])) {
+        free_range_mapping_array(result);
+        free_range_mapping_batch(batch);
+        return NULL;
       }
-      free_range_mapping_array(char_mappings);
     }
   }
-
-  // Propagate timeout status to caller
-  if (out_hit_timeout) {
-    *out_hit_timeout = any_timeout;
-  }
-
-  // Note: Whitespace-only change scanning happens in the main diff computer
-  // (between line diffs), not here. This function only refines existing diffs.
-
+  free_range_mapping_batch(batch);
   return result;
 }
 
@@ -962,4 +986,14 @@ void free_range_mapping_array(RangeMappingArray *arr) {
   if (arr->mappings)
     free(arr->mappings);
   free(arr);
+}
+
+void free_range_mapping_batch(RangeMappingBatch *batch) {
+  if (!batch)
+    return;
+  for (int i = 0; i < batch->count; i++) {
+    free(batch->results[i].mappings);
+  }
+  free(batch->results);
+  free(batch);
 }

--- a/libvscode-diff/tests/test_char_level.c
+++ b/libvscode-diff/tests/test_char_level.c
@@ -518,6 +518,31 @@ TEST(delete_and_add) {
   free_range_mapping_array(result2);
 }
 
+TEST(batched_refinement) {
+  const char *original[] = {"old alpha", "unchanged", "old beta"};
+  const char *modified[] = {"new alpha", "unchanged", "new beta"};
+  SequenceDiff diffs[] = {{0, 1, 0, 1}, {2, 3, 2, 3}};
+  SequenceDiffArray line_diffs = {.diffs = diffs, .count = 2, .capacity = 2};
+  CharLevelOptions opts = {
+      .consider_whitespace_changes = true, .extend_to_subwords = false, .timeout_ms = 5000};
+  bool hit_timeout = false;
+
+  RangeMappingBatch *batch =
+      refine_diffs_char_level(&line_diffs, original, 3, modified, 3, &opts, &hit_timeout);
+
+  ASSERT(batch != NULL, "Batch result should not be NULL");
+  ASSERT_EQ(batch->count, 2, "Batch should preserve input grouping");
+  ASSERT(batch->results[0].count > 0, "First range should have mappings");
+  ASSERT(batch->results[1].count > 0, "Second range should have mappings");
+  ASSERT(!hit_timeout, "Batch should not time out");
+  ASSERT_EQ(batch->results[0].mappings[0].original.start_line, 1,
+            "First result should use absolute lines");
+  ASSERT_EQ(batch->results[1].mappings[0].original.start_line, 3,
+            "Second result should use absolute lines");
+
+  free_range_mapping_batch(batch);
+}
+
 // =============================================================================
 // Main Test Runner
 // =============================================================================
@@ -537,6 +562,7 @@ int main(void) {
   RUN_TEST(real_code_function_rename);
   RUN_TEST(cross_line_range_mapping);
   RUN_TEST(delete_and_add);
+  RUN_TEST(batched_refinement);
 
   printf("\n");
   printf("=======================================================\n");

--- a/lua/codediff/config.lua
+++ b/lua/codediff/config.lua
@@ -1,6 +1,8 @@
 -- Configuration module
 local M = {}
 
+local line_matchers = require("codediff.line_matchers")
+
 M.defaults = {
   -- Highlight configuration
   highlights = {
@@ -33,6 +35,7 @@ M.defaults = {
     disable_inlay_hints = true, -- Disable inlay hints in diff windows for cleaner view
     max_computation_time_ms = 5000, -- Maximum time for diff computation (5 seconds, VSCode default)
     ignore_trim_whitespace = false, -- Ignore leading/trailing whitespace changes (like diffopt+=iwhite)
+    line_matcher = line_matchers.similarity, -- Pair similar changed lines for character-level highlights
     hide_merge_artifacts = false, -- Hide merge tool temp files (*.orig, *.BACKUP.*, *.BASE.*, *.LOCAL.*, *.REMOTE.*)
     original_position = "left", -- Position of original (old) content: "left" or "right"
     conflict_ours_position = "right", -- Position of ours (:2) in conflict view: "left" or "right" (independent of original_position)

--- a/lua/codediff/core/diff.lua
+++ b/lua/codediff/core/diff.lua
@@ -103,6 +103,11 @@ ffi.cdef([[
   } RangeMappingArray;
 
   typedef struct {
+    RangeMappingArray* results;
+    int count;
+  } RangeMappingBatch;
+
+  typedef struct {
     bool consider_whitespace_changes;
     bool extend_to_subwords;
     int timeout_ms;
@@ -165,8 +170,8 @@ ffi.cdef([[
     bool* hit_timeout
   );
 
-  RangeMappingArray* refine_diff_char_level(
-    const SequenceDiff* line_diff,
+  RangeMappingBatch* refine_diffs_char_level(
+    const SequenceDiffArray* line_diffs,
     const char** original_lines,
     int original_count,
     const char** modified_lines,
@@ -176,7 +181,7 @@ ffi.cdef([[
   );
 
   void free_lines_diff(LinesDiff* diff);
-  void free_range_mapping_array(RangeMappingArray* mappings);
+  void free_range_mapping_batch(RangeMappingBatch* batch);
   void free_sequence_diff_array(SequenceDiffArray* diff);
   const char* get_version(void);
 ]])
@@ -428,37 +433,7 @@ local function absolute_line_range(range, start_line)
   }
 end
 
--- Compute absolute character changes for one line-range mapping.
-local function compute_mapping_char_changes(original_lines, modified_lines, mapping, options)
-  local c_orig, orig_count = lua_to_c_strings(original_lines)
-  local c_mod, mod_count = lua_to_c_strings(modified_lines)
-  local c_mapping = ffi.new("SequenceDiff")
-  c_mapping.seq1_start = mapping.original.start_line - 1
-  c_mapping.seq1_end = mapping.original.end_line - 1
-  c_mapping.seq2_start = mapping.modified.start_line - 1
-  c_mapping.seq2_end = mapping.modified.end_line - 1
-
-  local c_options = ffi.new("CharLevelOptions")
-  c_options.consider_whitespace_changes = not options.ignore_trim_whitespace
-  c_options.extend_to_subwords = options.extend_to_subwords or false
-  c_options.timeout_ms = options.max_computation_time_ms or 5000
-
-  local hit_timeout = ffi.new("bool[1]")
-  local c_mappings = lib.refine_diff_char_level(c_mapping, c_orig, orig_count, c_mod, mod_count, c_options, hit_timeout)
-  if c_mappings == nil then
-    error("refine_diff_char_level returned NULL")
-  end
-
-  local inner_changes = {}
-  for index = 0, c_mappings.count - 1 do
-    inner_changes[#inner_changes + 1] = range_mapping_to_lua(c_mappings.mappings[index])
-  end
-
-  lib.free_range_mapping_array(c_mappings)
-  return inner_changes, hit_timeout[0]
-end
-
-local function apply_line_matcher(change, line_block, original_lines, modified_lines, matcher, options)
+local function collect_line_mappings(change, line_block, original_lines, modified_lines, matcher, selected)
   local context = {
     original_lines = slice_lines(original_lines, line_block.original.start_line, line_block.original.end_line),
     modified_lines = slice_lines(modified_lines, line_block.modified.start_line, line_block.modified.end_line),
@@ -468,20 +443,56 @@ local function apply_line_matcher(change, line_block, original_lines, modified_l
   local mappings = matcher(context)
   validate_line_mappings(mappings, context)
 
-  local hit_timeout = false
   for _, mapping in ipairs(mappings) do
     local refined_mapping = {
       original = absolute_line_range(mapping.original, line_block.original.start_line),
       modified = absolute_line_range(mapping.modified, line_block.modified.start_line),
+      inner_changes = {},
     }
-    local inner_changes, mapping_hit_timeout = compute_mapping_char_changes(original_lines, modified_lines, refined_mapping, options)
-    refined_mapping.inner_changes = inner_changes
     change.line_mappings[#change.line_mappings + 1] = refined_mapping
-    vim.list_extend(change.inner_changes, inner_changes)
-    hit_timeout = hit_timeout or mapping_hit_timeout
+    selected[#selected + 1] = { change = change, mapping = refined_mapping }
+  end
+end
+
+local function refine_line_mappings(selected, original_lines, modified_lines, options)
+  if #selected == 0 then
+    return false
   end
 
-  return hit_timeout
+  local c_orig, orig_count = lua_to_c_strings(original_lines)
+  local c_mod, mod_count = lua_to_c_strings(modified_lines)
+  local c_mappings = ffi.new("SequenceDiff[?]", #selected)
+  for index, selected_mapping in ipairs(selected) do
+    c_mappings[index - 1].seq1_start = selected_mapping.mapping.original.start_line - 1
+    c_mappings[index - 1].seq1_end = selected_mapping.mapping.original.end_line - 1
+    c_mappings[index - 1].seq2_start = selected_mapping.mapping.modified.start_line - 1
+    c_mappings[index - 1].seq2_end = selected_mapping.mapping.modified.end_line - 1
+  end
+  local c_mapping_array = ffi.new("SequenceDiffArray", { diffs = c_mappings, count = #selected, capacity = #selected })
+  local c_options = ffi.new("CharLevelOptions", {
+    consider_whitespace_changes = not options.ignore_trim_whitespace,
+    extend_to_subwords = options.extend_to_subwords or false,
+    timeout_ms = options.max_computation_time_ms or 5000,
+  })
+  local hit_timeout = ffi.new("bool[1]")
+  local batch = lib.refine_diffs_char_level(c_mapping_array, c_orig, orig_count, c_mod, mod_count, c_options, hit_timeout)
+  if batch == nil then
+    error("refine_diffs_char_level returned NULL")
+  end
+  if batch.count ~= #selected then
+    lib.free_range_mapping_batch(batch)
+    error("refine_diffs_char_level returned an unexpected result count")
+  end
+
+  for index, selected_mapping in ipairs(selected) do
+    local result = batch.results[index - 1]
+    for mapping_index = 0, result.count - 1 do
+      selected_mapping.mapping.inner_changes[#selected_mapping.mapping.inner_changes + 1] = range_mapping_to_lua(result.mappings[mapping_index])
+    end
+    vim.list_extend(selected_mapping.change.inner_changes, selected_mapping.mapping.inner_changes)
+  end
+  lib.free_range_mapping_batch(batch)
+  return hit_timeout[0]
 end
 
 -- Main API: Compute diff between two sets of lines
@@ -494,12 +505,14 @@ function M.compute_diff(original_lines, modified_lines, options)
     matcher = require("codediff.config").options.diff.line_matcher
   end
 
+  local selected = {}
   for _, change in ipairs(changes) do
     for _, line_block in ipairs(change.line_blocks) do
-      hit_timeout = apply_line_matcher(change, line_block, original_lines, modified_lines, matcher, options) or hit_timeout
+      collect_line_mappings(change, line_block, original_lines, modified_lines, matcher, selected)
     end
     change.line_blocks = nil
   end
+  hit_timeout = refine_line_mappings(selected, original_lines, modified_lines, options) or hit_timeout
 
   local moves = {}
   if options.compute_moves then

--- a/lua/codediff/core/diff.lua
+++ b/lua/codediff/core/diff.lua
@@ -97,6 +97,18 @@ ffi.cdef([[
   } RangeMapping;
 
   typedef struct {
+    RangeMapping* mappings;
+    int count;
+    int capacity;
+  } RangeMappingArray;
+
+  typedef struct {
+    bool consider_whitespace_changes;
+    bool extend_to_subwords;
+    int timeout_ms;
+  } CharLevelOptions;
+
+  typedef struct {
     LineRange original;
     LineRange modified;
     RangeMapping* inner_changes;
@@ -153,7 +165,18 @@ ffi.cdef([[
     bool* hit_timeout
   );
 
+  RangeMappingArray* refine_diff_char_level(
+    const SequenceDiff* line_diff,
+    const char** original_lines,
+    int original_count,
+    const char** modified_lines,
+    int modified_count,
+    const CharLevelOptions* options,
+    bool* hit_timeout
+  );
+
   void free_lines_diff(LinesDiff* diff);
+  void free_range_mapping_array(RangeMappingArray* mappings);
   void free_sequence_diff_array(SequenceDiffArray* diff);
   const char* get_version(void);
 ]])
@@ -279,10 +302,15 @@ local function compute_native_diff(original_lines, modified_lines, options)
 end
 
 local function append_change(changes, original_start, original_end, modified_start, modified_end)
+  local line_block = {
+    original = { start_line = original_start, end_line = original_end },
+    modified = { start_line = modified_start, end_line = modified_end },
+  }
   local previous = changes[#changes]
   if previous and previous.original.end_line >= original_start and previous.modified.end_line >= modified_start then
     previous.original.end_line = math.max(previous.original.end_line, original_end)
     previous.modified.end_line = math.max(previous.modified.end_line, modified_end)
+    previous.line_blocks[#previous.line_blocks + 1] = line_block
     return
   end
 
@@ -291,6 +319,7 @@ local function append_change(changes, original_start, original_end, modified_sta
     modified = { start_line = modified_start, end_line = modified_end },
     inner_changes = {},
     line_mappings = {},
+    line_blocks = { line_block },
   }
 end
 
@@ -350,15 +379,6 @@ local function slice_lines(lines, start_index, end_index)
   return result
 end
 
-local function offset_char_range(range, line_offset)
-  return {
-    start_line = range.start_line + line_offset,
-    start_col = range.start_col,
-    end_line = range.end_line + line_offset,
-    end_col = range.end_col,
-  }
-end
-
 local function validate_line_range(range, line_count, label)
   if type(range) ~= "table" then
     error(label .. " must be a table")
@@ -408,38 +428,42 @@ local function absolute_line_range(range, start_line)
   }
 end
 
--- Compute character changes for a line-range mapping and translate them to absolute file positions.
-local function compute_mapping_char_changes(context, mapping, absolute, options)
-  local mapping_diff = compute_native_diff(
-    slice_lines(context.original_lines, mapping.original.start_index, mapping.original.end_index),
-    slice_lines(context.modified_lines, mapping.modified.start_index, mapping.modified.end_index),
-    {
-      ignore_trim_whitespace = options.ignore_trim_whitespace,
-      max_computation_time_ms = options.max_computation_time_ms,
-      extend_to_subwords = options.extend_to_subwords,
-      compute_moves = false,
-    }
-  )
-  local inner_changes = {}
+-- Compute absolute character changes for one line-range mapping.
+local function compute_mapping_char_changes(original_lines, modified_lines, mapping, options)
+  local c_orig, orig_count = lua_to_c_strings(original_lines)
+  local c_mod, mod_count = lua_to_c_strings(modified_lines)
+  local c_mapping = ffi.new("SequenceDiff")
+  c_mapping.seq1_start = mapping.original.start_line - 1
+  c_mapping.seq1_end = mapping.original.end_line - 1
+  c_mapping.seq2_start = mapping.modified.start_line - 1
+  c_mapping.seq2_end = mapping.modified.end_line - 1
 
-  for _, change in ipairs(mapping_diff.changes) do
-    for _, inner in ipairs(change.inner_changes) do
-      inner_changes[#inner_changes + 1] = {
-        original = offset_char_range(inner.original, absolute.original.start_line - 1),
-        modified = offset_char_range(inner.modified, absolute.modified.start_line - 1),
-      }
-    end
+  local c_options = ffi.new("CharLevelOptions")
+  c_options.consider_whitespace_changes = not options.ignore_trim_whitespace
+  c_options.extend_to_subwords = options.extend_to_subwords or false
+  c_options.timeout_ms = options.max_computation_time_ms or 5000
+
+  local hit_timeout = ffi.new("bool[1]")
+  local c_mappings = lib.refine_diff_char_level(c_mapping, c_orig, orig_count, c_mod, mod_count, c_options, hit_timeout)
+  if c_mappings == nil then
+    error("refine_diff_char_level returned NULL")
   end
 
-  return inner_changes, mapping_diff.hit_timeout
+  local inner_changes = {}
+  for index = 0, c_mappings.count - 1 do
+    inner_changes[#inner_changes + 1] = range_mapping_to_lua(c_mappings.mappings[index])
+  end
+
+  lib.free_range_mapping_array(c_mappings)
+  return inner_changes, hit_timeout[0]
 end
 
-local function apply_line_matcher(change, original_lines, modified_lines, matcher, options)
+local function apply_line_matcher(change, line_block, original_lines, modified_lines, matcher, options)
   local context = {
-    original_lines = slice_lines(original_lines, change.original.start_line, change.original.end_line),
-    modified_lines = slice_lines(modified_lines, change.modified.start_line, change.modified.end_line),
-    original_start_line = change.original.start_line,
-    modified_start_line = change.modified.start_line,
+    original_lines = slice_lines(original_lines, line_block.original.start_line, line_block.original.end_line),
+    modified_lines = slice_lines(modified_lines, line_block.modified.start_line, line_block.modified.end_line),
+    original_start_line = line_block.original.start_line,
+    modified_start_line = line_block.modified.start_line,
   }
   local mappings = matcher(context)
   validate_line_mappings(mappings, context)
@@ -447,10 +471,10 @@ local function apply_line_matcher(change, original_lines, modified_lines, matche
   local hit_timeout = false
   for _, mapping in ipairs(mappings) do
     local refined_mapping = {
-      original = absolute_line_range(mapping.original, change.original.start_line),
-      modified = absolute_line_range(mapping.modified, change.modified.start_line),
+      original = absolute_line_range(mapping.original, line_block.original.start_line),
+      modified = absolute_line_range(mapping.modified, line_block.modified.start_line),
     }
-    local inner_changes, mapping_hit_timeout = compute_mapping_char_changes(context, mapping, refined_mapping, options)
+    local inner_changes, mapping_hit_timeout = compute_mapping_char_changes(original_lines, modified_lines, refined_mapping, options)
     refined_mapping.inner_changes = inner_changes
     change.line_mappings[#change.line_mappings + 1] = refined_mapping
     vim.list_extend(change.inner_changes, inner_changes)
@@ -471,7 +495,10 @@ function M.compute_diff(original_lines, modified_lines, options)
   end
 
   for _, change in ipairs(changes) do
-    hit_timeout = apply_line_matcher(change, original_lines, modified_lines, matcher, options) or hit_timeout
+    for _, line_block in ipairs(change.line_blocks) do
+      hit_timeout = apply_line_matcher(change, line_block, original_lines, modified_lines, matcher, options) or hit_timeout
+    end
+    change.line_blocks = nil
   end
 
   local moves = {}
@@ -487,6 +514,8 @@ function M.compute_diff(original_lines, modified_lines, options)
     hit_timeout = hit_timeout,
   }
 end
+
+M._compute_native_diff = compute_native_diff
 
 -- Get library version
 function M.get_version()

--- a/lua/codediff/core/diff.lua
+++ b/lua/codediff/core/diff.lua
@@ -66,6 +66,19 @@ end
 ffi.cdef([[
   // Basic range types
   typedef struct {
+    int seq1_start;
+    int seq1_end;
+    int seq2_start;
+    int seq2_end;
+  } SequenceDiff;
+
+  typedef struct {
+    SequenceDiff* diffs;
+    int count;
+    int capacity;
+  } SequenceDiffArray;
+
+  typedef struct {
     int start_line;  // 1-based, inclusive
     int end_line;    // 1-based, EXCLUSIVE
   } LineRange;
@@ -131,7 +144,17 @@ ffi.cdef([[
     const DiffOptions* options
   );
 
+  SequenceDiffArray* compute_line_alignments(
+    const char** original_lines,
+    int original_count,
+    const char** modified_lines,
+    int modified_count,
+    int timeout_ms,
+    bool* hit_timeout
+  );
+
   void free_lines_diff(LinesDiff* diff);
+  void free_sequence_diff_array(SequenceDiffArray* diff);
   const char* get_version(void);
 ]])
 
@@ -227,11 +250,7 @@ local function lines_diff_to_lua(c_diff)
   }
 end
 
--- Main API: Compute diff between two sets of lines
--- Returns Lua table representation of LinesDiff
-function M.compute_diff(original_lines, modified_lines, options)
-  options = options or {}
-
+local function compute_native_diff(original_lines, modified_lines, options)
   -- Convert Lua lines to C arrays
   local c_orig, orig_count = lua_to_c_strings(original_lines)
   local c_mod, mod_count = lua_to_c_strings(modified_lines)
@@ -247,7 +266,6 @@ function M.compute_diff(original_lines, modified_lines, options)
 
   -- Call C function
   local c_diff = lib.compute_diff(c_orig, orig_count, c_mod, mod_count, c_options)
-
   if c_diff == nil then
     error("compute_diff returned NULL")
   end
@@ -257,8 +275,169 @@ function M.compute_diff(original_lines, modified_lines, options)
 
   -- Free C memory
   lib.free_lines_diff(c_diff)
-
   return lua_diff
+end
+
+local function append_change(changes, original_start, original_end, modified_start, modified_end)
+  local previous = changes[#changes]
+  if previous and previous.original.end_line >= original_start and previous.modified.end_line >= modified_start then
+    previous.original.end_line = math.max(previous.original.end_line, original_end)
+    previous.modified.end_line = math.max(previous.modified.end_line, modified_end)
+    return
+  end
+
+  changes[#changes + 1] = {
+    original = { start_line = original_start, end_line = original_end },
+    modified = { start_line = modified_start, end_line = modified_end },
+    inner_changes = {},
+    line_pairs = {},
+  }
+end
+
+local function append_whitespace_changes(changes, original_lines, modified_lines, starts, count)
+  for offset = 0, count - 1 do
+    local original_index = starts.original + offset
+    local modified_index = starts.modified + offset
+    if original_lines[original_index] ~= modified_lines[modified_index] then
+      append_change(changes, original_index, original_index + 1, modified_index, modified_index + 1)
+    end
+  end
+end
+
+local function compute_line_changes(original_lines, modified_lines, options)
+  local c_orig, orig_count = lua_to_c_strings(original_lines)
+  local c_mod, mod_count = lua_to_c_strings(modified_lines)
+  local hit_timeout = ffi.new("bool[1]")
+  local c_diffs = lib.compute_line_alignments(c_orig, orig_count, c_mod, mod_count, options.max_computation_time_ms or 5000, hit_timeout)
+  if c_diffs == nil then
+    error("compute_line_alignments returned NULL")
+  end
+
+  local changes = {}
+  local previous_original = 0
+  local previous_modified = 0
+
+  for index = 0, c_diffs.count - 1 do
+    local line_diff = c_diffs.diffs[index]
+    if not options.ignore_trim_whitespace then
+      append_whitespace_changes(changes, original_lines, modified_lines, {
+        original = previous_original + 1,
+        modified = previous_modified + 1,
+      }, line_diff.seq1_start - previous_original)
+    end
+
+    append_change(changes, line_diff.seq1_start + 1, line_diff.seq1_end + 1, line_diff.seq2_start + 1, line_diff.seq2_end + 1)
+    previous_original = line_diff.seq1_end
+    previous_modified = line_diff.seq2_end
+  end
+
+  if not options.ignore_trim_whitespace then
+    append_whitespace_changes(changes, original_lines, modified_lines, {
+      original = previous_original + 1,
+      modified = previous_modified + 1,
+    }, math.min(orig_count - previous_original, mod_count - previous_modified))
+  end
+
+  lib.free_sequence_diff_array(c_diffs)
+  return changes, hit_timeout[0]
+end
+
+local function slice_lines(lines, line_range)
+  local result = {}
+  for line = line_range.start_line, line_range.end_line - 1 do
+    result[#result + 1] = lines[line]
+  end
+  return result
+end
+
+local function offset_char_range(range, line_offset)
+  return {
+    start_line = range.start_line + line_offset,
+    start_col = range.start_col,
+    end_line = range.end_line + line_offset,
+    end_col = range.end_col,
+  }
+end
+
+local function refine_pair(original_line, modified_line, positions, options)
+  local pair_diff = compute_native_diff({ original_line }, { modified_line }, {
+    ignore_trim_whitespace = options.ignore_trim_whitespace,
+    max_computation_time_ms = options.max_computation_time_ms,
+    extend_to_subwords = options.extend_to_subwords,
+    compute_moves = false,
+  })
+  local inner_changes = {}
+
+  for _, change in ipairs(pair_diff.changes) do
+    for _, inner in ipairs(change.inner_changes) do
+      inner_changes[#inner_changes + 1] = {
+        original = offset_char_range(inner.original, positions.original - 1),
+        modified = offset_char_range(inner.modified, positions.modified - 1),
+      }
+    end
+  end
+
+  return inner_changes, pair_diff.hit_timeout
+end
+
+local function apply_line_matcher(change, original_lines, modified_lines, matcher, options)
+  local context = {
+    original_lines = slice_lines(original_lines, change.original),
+    modified_lines = slice_lines(modified_lines, change.modified),
+    original_start_line = change.original.start_line,
+    modified_start_line = change.modified.start_line,
+  }
+
+  if #context.original_lines == 0 or #context.modified_lines == 0 then
+    return false
+  end
+
+  local hit_timeout = false
+  local pairs = matcher(context)
+  for _, pair in ipairs(pairs) do
+    local positions = {
+      original = change.original.start_line + pair.original_index - 1,
+      modified = change.modified.start_line + pair.modified_index - 1,
+    }
+    change.line_pairs[#change.line_pairs + 1] = {
+      original_line = positions.original,
+      modified_line = positions.modified,
+    }
+
+    local inner_changes, pair_hit_timeout = refine_pair(context.original_lines[pair.original_index], context.modified_lines[pair.modified_index], positions, options)
+    vim.list_extend(change.inner_changes, inner_changes)
+    hit_timeout = hit_timeout or pair_hit_timeout
+  end
+
+  return hit_timeout
+end
+
+-- Main API: Compute diff between two sets of lines
+-- Returns Lua table representation of LinesDiff
+function M.compute_diff(original_lines, modified_lines, options)
+  options = options or {}
+  local changes, hit_timeout = compute_line_changes(original_lines, modified_lines, options)
+  local matcher = options.line_matcher
+  if matcher == nil then
+    matcher = require("codediff.config").options.diff.line_matcher
+  end
+
+  for _, change in ipairs(changes) do
+    hit_timeout = apply_line_matcher(change, original_lines, modified_lines, matcher, options) or hit_timeout
+  end
+
+  local moves = {}
+  if options.compute_moves then
+    local move_diff = compute_native_diff(original_lines, modified_lines, options)
+    moves = move_diff.moves
+    hit_timeout = hit_timeout or move_diff.hit_timeout
+  end
+
+  return {
+    changes = changes,
+    moves = moves,
+    hit_timeout = hit_timeout,
+  }
 end
 
 -- Get library version

--- a/lua/codediff/core/diff.lua
+++ b/lua/codediff/core/diff.lua
@@ -290,7 +290,7 @@ local function append_change(changes, original_start, original_end, modified_sta
     original = { start_line = original_start, end_line = original_end },
     modified = { start_line = modified_start, end_line = modified_end },
     inner_changes = {},
-    line_pairs = {},
+    line_mappings = {},
   }
 end
 
@@ -342,10 +342,10 @@ local function compute_line_changes(original_lines, modified_lines, options)
   return changes, hit_timeout[0]
 end
 
-local function slice_lines(lines, line_range)
+local function slice_lines(lines, start_index, end_index)
   local result = {}
-  for line = line_range.start_line, line_range.end_line - 1 do
-    result[#result + 1] = lines[line]
+  for index = start_index, end_index - 1 do
+    result[#result + 1] = lines[index]
   end
   return result
 end
@@ -359,54 +359,102 @@ local function offset_char_range(range, line_offset)
   }
 end
 
-local function refine_pair(original_line, modified_line, positions, options)
-  local pair_diff = compute_native_diff({ original_line }, { modified_line }, {
-    ignore_trim_whitespace = options.ignore_trim_whitespace,
-    max_computation_time_ms = options.max_computation_time_ms,
-    extend_to_subwords = options.extend_to_subwords,
-    compute_moves = false,
-  })
+local function validate_line_range(range, line_count, label)
+  if type(range) ~= "table" then
+    error(label .. " must be a table")
+  end
+  if type(range.start_index) ~= "number" or range.start_index % 1 ~= 0 then
+    error(label .. ".start_index must be an integer")
+  end
+  if type(range.end_index) ~= "number" or range.end_index % 1 ~= 0 then
+    error(label .. ".end_index must be an integer")
+  end
+  if range.start_index < 1 or range.end_index < range.start_index or range.end_index > line_count + 1 then
+    error(label .. " is out of bounds")
+  end
+end
+
+-- Validate that matcher output contains ordered, non-overlapping ranges within the changed block.
+local function validate_line_mappings(mappings, context)
+  if type(mappings) ~= "table" then
+    error("line matcher must return a table")
+  end
+
+  local previous
+  for index, mapping in ipairs(mappings) do
+    local label = "line mapping " .. index
+    if type(mapping) ~= "table" then
+      error(label .. " must be a table")
+    end
+    validate_line_range(mapping.original, #context.original_lines, label .. ".original")
+    validate_line_range(mapping.modified, #context.modified_lines, label .. ".modified")
+
+    local original_empty = mapping.original.start_index == mapping.original.end_index
+    local modified_empty = mapping.modified.start_index == mapping.modified.end_index
+    if original_empty and modified_empty then
+      error(label .. " cannot be empty on both sides")
+    end
+    if previous and (mapping.original.start_index < previous.original.end_index or mapping.modified.start_index < previous.modified.end_index) then
+      error("line mappings must be ordered and non-overlapping")
+    end
+    previous = mapping
+  end
+end
+
+local function absolute_line_range(range, start_line)
+  return {
+    start_line = start_line + range.start_index - 1,
+    end_line = start_line + range.end_index - 1,
+  }
+end
+
+-- Compute character changes for a line-range mapping and translate them to absolute file positions.
+local function compute_mapping_char_changes(context, mapping, absolute, options)
+  local mapping_diff = compute_native_diff(
+    slice_lines(context.original_lines, mapping.original.start_index, mapping.original.end_index),
+    slice_lines(context.modified_lines, mapping.modified.start_index, mapping.modified.end_index),
+    {
+      ignore_trim_whitespace = options.ignore_trim_whitespace,
+      max_computation_time_ms = options.max_computation_time_ms,
+      extend_to_subwords = options.extend_to_subwords,
+      compute_moves = false,
+    }
+  )
   local inner_changes = {}
 
-  for _, change in ipairs(pair_diff.changes) do
+  for _, change in ipairs(mapping_diff.changes) do
     for _, inner in ipairs(change.inner_changes) do
       inner_changes[#inner_changes + 1] = {
-        original = offset_char_range(inner.original, positions.original - 1),
-        modified = offset_char_range(inner.modified, positions.modified - 1),
+        original = offset_char_range(inner.original, absolute.original.start_line - 1),
+        modified = offset_char_range(inner.modified, absolute.modified.start_line - 1),
       }
     end
   end
 
-  return inner_changes, pair_diff.hit_timeout
+  return inner_changes, mapping_diff.hit_timeout
 end
 
 local function apply_line_matcher(change, original_lines, modified_lines, matcher, options)
   local context = {
-    original_lines = slice_lines(original_lines, change.original),
-    modified_lines = slice_lines(modified_lines, change.modified),
+    original_lines = slice_lines(original_lines, change.original.start_line, change.original.end_line),
+    modified_lines = slice_lines(modified_lines, change.modified.start_line, change.modified.end_line),
     original_start_line = change.original.start_line,
     modified_start_line = change.modified.start_line,
   }
-
-  if #context.original_lines == 0 or #context.modified_lines == 0 then
-    return false
-  end
+  local mappings = matcher(context)
+  validate_line_mappings(mappings, context)
 
   local hit_timeout = false
-  local pairs = matcher(context)
-  for _, pair in ipairs(pairs) do
-    local positions = {
-      original = change.original.start_line + pair.original_index - 1,
-      modified = change.modified.start_line + pair.modified_index - 1,
+  for _, mapping in ipairs(mappings) do
+    local refined_mapping = {
+      original = absolute_line_range(mapping.original, change.original.start_line),
+      modified = absolute_line_range(mapping.modified, change.modified.start_line),
     }
-    change.line_pairs[#change.line_pairs + 1] = {
-      original_line = positions.original,
-      modified_line = positions.modified,
-    }
-
-    local inner_changes, pair_hit_timeout = refine_pair(context.original_lines[pair.original_index], context.modified_lines[pair.modified_index], positions, options)
+    local inner_changes, mapping_hit_timeout = compute_mapping_char_changes(context, mapping, refined_mapping, options)
+    refined_mapping.inner_changes = inner_changes
+    change.line_mappings[#change.line_mappings + 1] = refined_mapping
     vim.list_extend(change.inner_changes, inner_changes)
-    hit_timeout = hit_timeout or pair_hit_timeout
+    hit_timeout = hit_timeout or mapping_hit_timeout
   end
 
   return hit_timeout

--- a/lua/codediff/line_matchers.lua
+++ b/lua/codediff/line_matchers.lua
@@ -59,7 +59,7 @@ local function find_best_pair(context, range, threshold)
   return best
 end
 
-local function collect_similar_pairs(context, range, threshold, pairs)
+local function collect_similar_mappings(context, range, threshold, mappings)
   if range.original_start > range.original_end or range.modified_start > range.modified_end then
     return
   end
@@ -69,40 +69,46 @@ local function collect_similar_pairs(context, range, threshold, pairs)
     return
   end
 
-  collect_similar_pairs(context, {
+  collect_similar_mappings(context, {
     original_start = range.original_start,
     original_end = best.original_index - 1,
     modified_start = range.modified_start,
     modified_end = best.modified_index - 1,
-  }, threshold, pairs)
+  }, threshold, mappings)
 
-  pairs[#pairs + 1] = {
-    original_index = best.original_index,
-    modified_index = best.modified_index,
+  mappings[#mappings + 1] = {
+    original = {
+      start_index = best.original_index,
+      end_index = best.original_index + 1,
+    },
+    modified = {
+      start_index = best.modified_index,
+      end_index = best.modified_index + 1,
+    },
   }
 
-  collect_similar_pairs(context, {
+  collect_similar_mappings(context, {
     original_start = best.original_index + 1,
     original_end = range.original_end,
     modified_start = best.modified_index + 1,
     modified_end = range.modified_end,
-  }, threshold, pairs)
+  }, threshold, mappings)
 end
 
 -- Pair similar original and modified lines in order using an optional similarity threshold.
 -- Example: left = "local old_name = 1", right = "local new_name = 1" gives 0.83.
 function M.similarity(context, options)
   local threshold = options and options.threshold or DEFAULT_THRESHOLD
-  local pairs = {}
+  local mappings = {}
 
-  collect_similar_pairs(context, {
+  collect_similar_mappings(context, {
     original_start = 1,
     original_end = #context.original_lines,
     modified_start = 1,
     modified_end = #context.modified_lines,
-  }, threshold, pairs)
+  }, threshold, mappings)
 
-  return pairs
+  return mappings
 end
 
 -- Pair original and modified lines by position only when both sides have equal line counts (GitHub-style).
@@ -113,14 +119,14 @@ function M.equal_line_count(context)
     return {}
   end
 
-  local pairs = {}
+  local mappings = {}
   for index = 1, #context.original_lines do
-    pairs[index] = {
-      original_index = index,
-      modified_index = index,
+    mappings[index] = {
+      original = { start_index = index, end_index = index + 1 },
+      modified = { start_index = index, end_index = index + 1 },
     }
   end
-  return pairs
+  return mappings
 end
 
 function M.none(_context)

--- a/lua/codediff/line_matchers.lua
+++ b/lua/codediff/line_matchers.lua
@@ -1,0 +1,130 @@
+local M = {}
+
+-- Inspired by CPython difflib.Differ._fancy_replace: https://github.com/python/cpython/blob/1736526023a3e616d1530815880bb3b28e3433c3/Lib/difflib.py#L896-L988
+local DEFAULT_THRESHOLD = 0.75
+local SEARCH_WINDOW = 10
+
+local function lcs_length(left, right)
+  local previous = {}
+  for right_index = 0, #right do
+    previous[right_index] = 0
+  end
+
+  for left_index = 1, #left do
+    local current = { [0] = 0 }
+    local left_char = left:sub(left_index, left_index)
+    for right_index = 1, #right do
+      if left_char == right:sub(right_index, right_index) then
+        current[right_index] = previous[right_index - 1] + 1
+      else
+        current[right_index] = math.max(previous[right_index], current[right_index - 1])
+      end
+    end
+    previous = current
+  end
+
+  return previous[#right]
+end
+
+local function similarity_score(left, right)
+  if left == right then
+    return 1
+  end
+  if #left == 0 or #right == 0 then
+    return 0
+  end
+  return 2 * lcs_length(left, right) / (#left + #right)
+end
+
+local function find_best_pair(context, range, threshold)
+  local best
+
+  for original_index = range.original_start, range.original_end do
+    local expected_modified = range.modified_start + original_index - range.original_start
+    local modified_start = math.max(range.modified_start, expected_modified - SEARCH_WINDOW)
+    local modified_end = math.min(range.modified_end, expected_modified + SEARCH_WINDOW)
+
+    for modified_index = modified_start, modified_end do
+      local score = similarity_score(context.original_lines[original_index], context.modified_lines[modified_index])
+      if score >= threshold and (not best or score > best.score) then
+        best = {
+          original_index = original_index,
+          modified_index = modified_index,
+          score = score,
+        }
+      end
+    end
+  end
+
+  return best
+end
+
+local function collect_similar_pairs(context, range, threshold, pairs)
+  if range.original_start > range.original_end or range.modified_start > range.modified_end then
+    return
+  end
+
+  local best = find_best_pair(context, range, threshold)
+  if not best then
+    return
+  end
+
+  collect_similar_pairs(context, {
+    original_start = range.original_start,
+    original_end = best.original_index - 1,
+    modified_start = range.modified_start,
+    modified_end = best.modified_index - 1,
+  }, threshold, pairs)
+
+  pairs[#pairs + 1] = {
+    original_index = best.original_index,
+    modified_index = best.modified_index,
+  }
+
+  collect_similar_pairs(context, {
+    original_start = best.original_index + 1,
+    original_end = range.original_end,
+    modified_start = best.modified_index + 1,
+    modified_end = range.modified_end,
+  }, threshold, pairs)
+end
+
+-- Pair similar original and modified lines in order using an optional similarity threshold.
+-- Example: left = "local old_name = 1", right = "local new_name = 1" gives 0.83.
+function M.similarity(context, options)
+  local threshold = options and options.threshold or DEFAULT_THRESHOLD
+  local pairs = {}
+
+  collect_similar_pairs(context, {
+    original_start = 1,
+    original_end = #context.original_lines,
+    modified_start = 1,
+    modified_end = #context.modified_lines,
+  }, threshold, pairs)
+
+  return pairs
+end
+
+-- Pair original and modified lines by position only when both sides have equal line counts (GitHub-style).
+-- Example: left = { "line1", "line2" }, right = { "line3", "line4" } pairs 1:1 and 2:2.
+-- Example: left = { "line1" }, right = { "line2", "line3" } returns no pairs.
+function M.equal_line_count(context)
+  if #context.original_lines ~= #context.modified_lines then
+    return {}
+  end
+
+  local pairs = {}
+  for index = 1, #context.original_lines do
+    pairs[index] = {
+      original_index = index,
+      modified_index = index,
+    }
+  end
+  return pairs
+end
+
+function M.none(_context)
+  return {}
+end
+
+return M

--- a/lua/codediff/line_matchers.lua
+++ b/lua/codediff/line_matchers.lua
@@ -129,6 +129,19 @@ function M.equal_line_count(context)
   return mappings
 end
 
+function M.vscode(context)
+  if #context.original_lines == 0 and #context.modified_lines == 0 then
+    return {}
+  end
+
+  return {
+    {
+      original = { start_index = 1, end_index = #context.original_lines + 1 },
+      modified = { start_index = 1, end_index = #context.modified_lines + 1 },
+    },
+  }
+end
+
 function M.none(_context)
   return {}
 end

--- a/lua/codediff/ui/core.lua
+++ b/lua/codediff/ui/core.lua
@@ -191,47 +191,37 @@ end
 -- Step 3: Filler Line Calculation
 -- ============================================================================
 
-local function calculate_fillers(mapping)
-  local fillers = {}
-  local original_line = mapping.original.start_line
-  local modified_line = mapping.modified.start_line
-
-  for _, pair in ipairs(mapping.line_pairs) do
-    local original_count = pair.original_line - original_line
-    local modified_count = pair.modified_line - modified_line
-    if original_count > modified_count then
-      fillers[#fillers + 1] = {
-        buffer = "modified",
-        after_line = pair.modified_line - 1,
-        count = original_count - modified_count,
-      }
-    elseif modified_count > original_count then
-      fillers[#fillers + 1] = {
-        buffer = "original",
-        after_line = pair.original_line - 1,
-        count = modified_count - original_count,
-      }
-    end
-    original_line = pair.original_line + 1
-    modified_line = pair.modified_line + 1
-  end
-
-  local original_count = mapping.original.end_line - original_line
-  local modified_count = mapping.modified.end_line - modified_line
+local function append_filler(fillers, original_start, original_end, modified_start, modified_end)
+  local original_count = original_end - original_start
+  local modified_count = modified_end - modified_start
   if original_count > modified_count then
     fillers[#fillers + 1] = {
       buffer = "modified",
-      after_line = mapping.modified.end_line - 1,
+      after_line = modified_end - 1,
       count = original_count - modified_count,
     }
   elseif modified_count > original_count then
     fillers[#fillers + 1] = {
       buffer = "original",
-      after_line = mapping.original.end_line - 1,
+      after_line = original_end - 1,
       count = modified_count - original_count,
     }
   end
+end
 
+local function calculate_fillers(mapping)
+  local fillers = {}
+  local original_line = mapping.original.start_line
+  local modified_line = mapping.modified.start_line
+
+  for _, line_mapping in ipairs(mapping.line_mappings) do
+    append_filler(fillers, original_line, line_mapping.original.start_line, modified_line, line_mapping.modified.start_line)
+    append_filler(fillers, line_mapping.original.start_line, line_mapping.original.end_line, line_mapping.modified.start_line, line_mapping.modified.end_line)
+    original_line = line_mapping.original.end_line
+    modified_line = line_mapping.modified.end_line
+  end
+
+  append_filler(fillers, original_line, mapping.original.end_line, modified_line, mapping.modified.end_line)
   return fillers
 end
 

--- a/lua/codediff/ui/core.lua
+++ b/lua/codediff/ui/core.lua
@@ -191,118 +191,48 @@ end
 -- Step 3: Filler Line Calculation
 -- ============================================================================
 
-local function calculate_fillers(mapping, original_lines, _modified_lines, last_orig_line, last_mod_line)
+local function calculate_fillers(mapping)
   local fillers = {}
+  local original_line = mapping.original.start_line
+  local modified_line = mapping.modified.start_line
 
-  last_orig_line = last_orig_line or mapping.original.start_line
-  last_mod_line = last_mod_line or mapping.modified.start_line
-
-  if not mapping.inner_changes or #mapping.inner_changes == 0 then
-    local mapping_orig_lines = mapping.original.end_line - mapping.original.start_line
-    local mapping_mod_lines = mapping.modified.end_line - mapping.modified.start_line
-
-    if mapping_orig_lines > mapping_mod_lines then
-      local diff = mapping_orig_lines - mapping_mod_lines
-      table.insert(fillers, {
+  for _, pair in ipairs(mapping.line_pairs) do
+    local original_count = pair.original_line - original_line
+    local modified_count = pair.modified_line - modified_line
+    if original_count > modified_count then
+      fillers[#fillers + 1] = {
         buffer = "modified",
-        after_line = mapping.modified.start_line - 1,
-        count = diff,
-      })
-    elseif mapping_mod_lines > mapping_orig_lines then
-      local diff = mapping_mod_lines - mapping_orig_lines
-      table.insert(fillers, {
+        after_line = pair.modified_line - 1,
+        count = original_count - modified_count,
+      }
+    elseif modified_count > original_count then
+      fillers[#fillers + 1] = {
         buffer = "original",
-        after_line = mapping.original.start_line - 1,
-        count = diff,
-      })
+        after_line = pair.original_line - 1,
+        count = modified_count - original_count,
+      }
     end
-    return fillers, mapping.original.end_line, mapping.modified.end_line
+    original_line = pair.original_line + 1
+    modified_line = pair.modified_line + 1
   end
 
-  local alignments = {}
-  local first = true
-
-  local function handle_gap_alignment(orig_line_exclusive, mod_line_exclusive)
-    local orig_gap = orig_line_exclusive - last_orig_line
-    local mod_gap = mod_line_exclusive - last_mod_line
-
-    if orig_gap > 0 or mod_gap > 0 then
-      table.insert(alignments, {
-        orig_start = last_orig_line,
-        orig_end = orig_line_exclusive,
-        mod_start = last_mod_line,
-        mod_end = mod_line_exclusive,
-        orig_len = orig_gap,
-        mod_len = mod_gap,
-      })
-      last_orig_line = orig_line_exclusive
-      last_mod_line = mod_line_exclusive
-    end
+  local original_count = mapping.original.end_line - original_line
+  local modified_count = mapping.modified.end_line - modified_line
+  if original_count > modified_count then
+    fillers[#fillers + 1] = {
+      buffer = "modified",
+      after_line = mapping.modified.end_line - 1,
+      count = original_count - modified_count,
+    }
+  elseif modified_count > original_count then
+    fillers[#fillers + 1] = {
+      buffer = "original",
+      after_line = mapping.original.end_line - 1,
+      count = modified_count - original_count,
+    }
   end
 
-  handle_gap_alignment(mapping.original.start_line, mapping.modified.start_line)
-
-  local function emit_alignment(orig_line_exclusive, mod_line_exclusive)
-    if orig_line_exclusive < last_orig_line or mod_line_exclusive < last_mod_line then
-      return
-    end
-
-    if first then
-      first = false
-    elseif orig_line_exclusive == last_orig_line or mod_line_exclusive == last_mod_line then
-      return
-    end
-
-    local orig_range_len = orig_line_exclusive - last_orig_line
-    local mod_range_len = mod_line_exclusive - last_mod_line
-
-    if orig_range_len > 0 or mod_range_len > 0 then
-      table.insert(alignments, {
-        orig_start = last_orig_line,
-        orig_end = orig_line_exclusive,
-        mod_start = last_mod_line,
-        mod_end = mod_line_exclusive,
-        orig_len = orig_range_len,
-        mod_len = mod_range_len,
-      })
-    end
-
-    last_orig_line = orig_line_exclusive
-    last_mod_line = mod_line_exclusive
-  end
-
-  for _, inner in ipairs(mapping.inner_changes) do
-    if inner.original.start_col > 1 and inner.modified.start_col > 1 then
-      emit_alignment(inner.original.start_line, inner.modified.start_line)
-    end
-
-    local orig_line_len = original_lines[inner.original.end_line] and #original_lines[inner.original.end_line] or 0
-    if inner.original.end_col <= orig_line_len then
-      emit_alignment(inner.original.end_line, inner.modified.end_line)
-    end
-  end
-
-  emit_alignment(mapping.original.end_line, mapping.modified.end_line)
-
-  for _, align in ipairs(alignments) do
-    local line_diff = align.mod_len - align.orig_len
-
-    if line_diff > 0 then
-      table.insert(fillers, {
-        buffer = "original",
-        after_line = align.orig_end - 1,
-        count = line_diff,
-      })
-    elseif line_diff < 0 then
-      table.insert(fillers, {
-        buffer = "modified",
-        after_line = align.mod_end - 1,
-        count = -line_diff,
-      })
-    end
-  end
-
-  return fillers, last_orig_line, last_mod_line
+  return fillers
 end
 
 -- ============================================================================
@@ -320,9 +250,6 @@ function M.render_diff(left_bufnr, right_bufnr, original_lines, modified_lines, 
 
   local total_left_fillers = 0
   local total_right_fillers = 0
-
-  local last_orig_line = 1
-  local last_mod_line = 1
 
   for _, mapping in ipairs(lines_diff.changes) do
     local orig_is_empty = (mapping.original.end_line <= mapping.original.start_line)
@@ -348,10 +275,7 @@ function M.render_diff(left_bufnr, right_bufnr, original_lines, modified_lines, 
       end
     end
 
-    local fillers, new_last_orig, new_last_mod = calculate_fillers(mapping, original_lines, modified_lines, last_orig_line, last_mod_line)
-
-    last_orig_line = new_last_orig
-    last_mod_line = new_last_mod
+    local fillers = calculate_fillers(mapping)
 
     for _, filler in ipairs(fillers) do
       if filler.buffer == "original" then

--- a/lua/codediff/ui/core.lua
+++ b/lua/codediff/ui/core.lua
@@ -191,36 +191,96 @@ end
 -- Step 3: Filler Line Calculation
 -- ============================================================================
 
-local function append_filler(fillers, original_start, original_end, modified_start, modified_end)
-  local original_count = original_end - original_start
-  local modified_count = modified_end - modified_start
+local function append_filler_counts(fillers, original_count, modified_count, original_after_line, modified_after_line)
   if original_count > modified_count then
     fillers[#fillers + 1] = {
       buffer = "modified",
-      after_line = modified_end - 1,
+      after_line = modified_after_line,
       count = original_count - modified_count,
     }
   elseif modified_count > original_count then
     fillers[#fillers + 1] = {
       buffer = "original",
-      after_line = original_end - 1,
+      after_line = original_after_line,
       count = modified_count - original_count,
     }
   end
 end
 
-local function calculate_fillers(mapping)
+local function append_filler(fillers, original_start, original_end, modified_start, modified_end)
+  append_filler_counts(fillers, original_end - original_start, modified_end - modified_start, original_end - 1, modified_end - 1)
+end
+
+local function mappings_cover_change(mapping)
+  local original_line = mapping.original.start_line
+  local modified_line = mapping.modified.start_line
+  for _, line_mapping in ipairs(mapping.line_mappings) do
+    if line_mapping.original.start_line ~= original_line or line_mapping.modified.start_line ~= modified_line then
+      return false
+    end
+    original_line = line_mapping.original.end_line
+    modified_line = line_mapping.modified.end_line
+  end
+  return original_line == mapping.original.end_line and modified_line == mapping.modified.end_line
+end
+
+local function append_inner_alignment(fillers, state, original_end, modified_end)
+  if original_end < state.original_line or modified_end < state.modified_line then
+    return
+  end
+  if not state.first and (original_end == state.original_line or modified_end == state.modified_line) then
+    return
+  end
+
+  state.first = false
+  append_filler(fillers, state.original_line, original_end, state.modified_line, modified_end)
+  state.original_line = original_end
+  state.modified_line = modified_end
+end
+
+local function calculate_inner_change_fillers(mapping, original_lines)
+  local original_count = mapping.original.end_line - mapping.original.start_line
+  local modified_count = mapping.modified.end_line - mapping.modified.start_line
+  if #mapping.inner_changes == 0 then
+    local fillers = {}
+    append_filler_counts(fillers, original_count, modified_count, mapping.original.start_line - 1, mapping.modified.start_line - 1)
+    return fillers
+  end
+
+  local fillers = {}
+  local state = {
+    original_line = mapping.original.start_line,
+    modified_line = mapping.modified.start_line,
+    first = true,
+  }
+  for _, inner in ipairs(mapping.inner_changes) do
+    if inner.original.start_col > 1 and inner.modified.start_col > 1 then
+      append_inner_alignment(fillers, state, inner.original.start_line, inner.modified.start_line)
+    end
+
+    local original_line_length = original_lines[inner.original.end_line] and #original_lines[inner.original.end_line] or 0
+    if inner.original.end_col <= original_line_length then
+      append_inner_alignment(fillers, state, inner.original.end_line, inner.modified.end_line)
+    end
+  end
+  append_inner_alignment(fillers, state, mapping.original.end_line, mapping.modified.end_line)
+  return fillers
+end
+
+local function calculate_fillers(mapping, original_lines)
+  if mappings_cover_change(mapping) then
+    return calculate_inner_change_fillers(mapping, original_lines)
+  end
+
   local fillers = {}
   local original_line = mapping.original.start_line
   local modified_line = mapping.modified.start_line
-
   for _, line_mapping in ipairs(mapping.line_mappings) do
     append_filler(fillers, original_line, line_mapping.original.start_line, modified_line, line_mapping.modified.start_line)
     append_filler(fillers, line_mapping.original.start_line, line_mapping.original.end_line, line_mapping.modified.start_line, line_mapping.modified.end_line)
     original_line = line_mapping.original.end_line
     modified_line = line_mapping.modified.end_line
   end
-
   append_filler(fillers, original_line, mapping.original.end_line, modified_line, mapping.modified.end_line)
   return fillers
 end
@@ -265,7 +325,7 @@ function M.render_diff(left_bufnr, right_bufnr, original_lines, modified_lines, 
       end
     end
 
-    local fillers = calculate_fillers(mapping)
+    local fillers = calculate_fillers(mapping, original_lines)
 
     for _, filler in ipairs(fillers) do
       if filler.buffer == "original" then

--- a/lua/codediff/ui/merge_alignment.lua
+++ b/lua/codediff/ui/merge_alignment.lua
@@ -428,9 +428,7 @@ function M.compute_merge_fillers_and_conflicts(base_to_input1_diff, base_to_inpu
   for _, ma in ipairs(mapping_alignments) do
     -- A region is conflicting if BOTH sides have changes (inner1 and inner2 both non-empty)
     -- OR if both sides have changes (checked by looking at if the ranges differ from base)
-    local has_left_changes = #ma.inner1 > 0 or (ma.output1_range.end_line - ma.output1_range.start_line) ~= (ma.base_range.end_line - ma.base_range.start_line)
-    local has_right_changes = #ma.inner2 > 0 or (ma.output2_range.end_line - ma.output2_range.start_line) ~= (ma.base_range.end_line - ma.base_range.start_line)
-    local is_conflict = has_left_changes and has_right_changes
+    local is_conflict = ma.has_input1 and ma.has_input2
 
     if is_conflict then
       -- Add to conflict blocks for action handling

--- a/tests/core/line_matchers_spec.lua
+++ b/tests/core/line_matchers_spec.lua
@@ -49,6 +49,50 @@ describe("Line matchers", function()
     end)
   end
 
+  local vscode_cases = {
+    {
+      name = "maps an entire mixed block",
+      context = { original_lines = { "one", "two" }, modified_lines = { "ONE" } },
+      expected = {
+        {
+          original = { start_index = 1, end_index = 3 },
+          modified = { start_index = 1, end_index = 2 },
+        },
+      },
+    },
+    {
+      name = "maps an entire pure insertion",
+      context = { original_lines = {}, modified_lines = { "one", "two" } },
+      expected = {
+        {
+          original = { start_index = 1, end_index = 1 },
+          modified = { start_index = 1, end_index = 3 },
+        },
+      },
+    },
+    {
+      name = "maps an entire pure deletion",
+      context = { original_lines = { "one", "two" }, modified_lines = {} },
+      expected = {
+        {
+          original = { start_index = 1, end_index = 3 },
+          modified = { start_index = 1, end_index = 1 },
+        },
+      },
+    },
+    {
+      name = "returns no mapping for an empty block",
+      context = { original_lines = {}, modified_lines = {} },
+      expected = {},
+    },
+  }
+
+  for _, test_case in ipairs(vscode_cases) do
+    it(test_case.name, function()
+      assert.same(test_case.expected, line_matchers.vscode(test_case.context))
+    end)
+  end
+
   it("uses a configurable similarity threshold", function()
     local similar_context = {
       original_lines = { "cat" },
@@ -173,6 +217,19 @@ describe("Line matchers", function()
       assert.same(test_case.expected_modified, result.changes[1].line_mappings[1].modified)
     end)
   end
+
+  it("preserves VS Code character mappings for pure changes", function()
+    local result = diff.compute_diff({ "before", "after" }, { "before", "added", "after" }, {
+      line_matcher = line_matchers.vscode,
+    })
+
+    assert.same({
+      {
+        original = { start_line = 2, start_col = 1, end_line = 2, end_col = 1 },
+        modified = { start_line = 2, start_col = 1, end_line = 3, end_col = 1 },
+      },
+    }, result.changes[1].inner_changes)
+  end)
 
   it("omits character changes when matching is disabled", function()
     local result = diff.compute_diff({ "old value" }, { "new value" }, {

--- a/tests/core/line_matchers_spec.lua
+++ b/tests/core/line_matchers_spec.lua
@@ -8,18 +8,33 @@ local context = {
   modified_start_line = 7,
 }
 
+local one_line_mapping = function(original_index, modified_index)
+  return {
+    original = { start_index = original_index, end_index = original_index + 1 },
+    modified = { start_index = modified_index, end_index = modified_index + 1 },
+  }
+end
+
+local compute_with_mappings = function(mappings)
+  return diff.compute_diff({ "original one", "original two" }, { "modified one", "modified two" }, {
+    line_matcher = function()
+      return mappings
+    end,
+  })
+end
+
 describe("Line matchers", function()
   local equal_line_count_cases = {
     {
-      name = "pairs equal line counts by position",
+      name = "maps equal line counts by position",
       context = context,
       expected = {
-        { original_index = 1, modified_index = 1 },
-        { original_index = 2, modified_index = 2 },
+        one_line_mapping(1, 1),
+        one_line_mapping(2, 2),
       },
     },
     {
-      name = "does not pair unequal line counts",
+      name = "does not map unequal line counts",
       context = {
         original_lines = { "one" },
         modified_lines = { "ONE", "extra" },
@@ -42,23 +57,23 @@ describe("Line matchers", function()
 
     assert.same({}, line_matchers.similarity(similar_context))
     assert.same(
-      { { original_index = 1, modified_index = 1 } },
+      { one_line_mapping(1, 1) },
       line_matchers.similarity(similar_context, {
         threshold = 0.6,
       })
     )
   end)
 
-  it("returns ordered similarity pairs and leaves unrelated lines unpaired", function()
-    local pairs = line_matchers.similarity({
+  it("returns ordered similarity mappings and leaves unrelated lines unmapped", function()
+    local mappings = line_matchers.similarity({
       original_lines = { "local old_name = 1", "removed without match", "print(old_name)" },
       modified_lines = { "local new_name = 1", "print(new_name)", "unrelated insertion" },
     })
 
     assert.same({
-      { original_index = 1, modified_index = 1 },
-      { original_index = 3, modified_index = 2 },
-    }, pairs)
+      one_line_mapping(1, 1),
+      one_line_mapping(3, 2),
+    }, mappings)
   end)
 
   it("passes changed block context to a custom matcher", function()
@@ -66,7 +81,7 @@ describe("Line matchers", function()
     local result = diff.compute_diff({ "before", "old value", "deleted" }, { "before", "new value", "inserted" }, {
       line_matcher = function(matcher_context)
         received_context = matcher_context
-        return { { original_index = 1, modified_index = 1 } }
+        return { one_line_mapping(1, 1) }
       end,
     })
 
@@ -74,16 +89,146 @@ describe("Line matchers", function()
     assert.same({ "new value", "inserted" }, received_context.modified_lines)
     assert.equal(2, received_context.original_start_line)
     assert.equal(2, received_context.modified_start_line)
-    assert.same({ { original_line = 2, modified_line = 2 } }, result.changes[1].line_pairs)
+    assert.same({ start_line = 2, end_line = 3 }, result.changes[1].line_mappings[1].original)
+    assert.same({ start_line = 2, end_line = 3 }, result.changes[1].line_mappings[1].modified)
     assert.is_true(#result.changes[1].inner_changes > 0)
   end)
+
+  it("refines a one-to-many line mapping", function()
+    local result = diff.compute_diff({ "before", "local result = prefix .. value", "after" }, { "before", "local result = prefix", "  .. value", "after" }, {
+      line_matcher = function()
+        return {
+          {
+            original = { start_index = 1, end_index = 2 },
+            modified = { start_index = 1, end_index = 3 },
+          },
+        }
+      end,
+    })
+
+    local mapping = result.changes[1].line_mappings[1]
+    assert.same({ start_line = 2, end_line = 3 }, mapping.original)
+    assert.same({ start_line = 2, end_line = 4 }, mapping.modified)
+    assert.is_true(#mapping.inner_changes > 0)
+  end)
+
+  it("refines a many-to-one line mapping", function()
+    local result = diff.compute_diff({ "before", "local result = prefix", "  .. value", "after" }, { "before", "local result = prefix .. value", "after" }, {
+      line_matcher = function()
+        return {
+          {
+            original = { start_index = 1, end_index = 3 },
+            modified = { start_index = 1, end_index = 2 },
+          },
+        }
+      end,
+    })
+
+    local mapping = result.changes[1].line_mappings[1]
+    assert.same({ start_line = 2, end_line = 4 }, mapping.original)
+    assert.same({ start_line = 2, end_line = 3 }, mapping.modified)
+    assert.is_true(#mapping.inner_changes > 0)
+  end)
+
+  local pure_change_cases = {
+    {
+      name = "allows a custom matcher to map a pure insertion",
+      original = { "before", "after" },
+      modified = { "before", "added", "after" },
+      mapping = {
+        original = { start_index = 1, end_index = 1 },
+        modified = { start_index = 1, end_index = 2 },
+      },
+      expected_context = { original = {}, modified = { "added" } },
+      expected_original = { start_line = 2, end_line = 2 },
+      expected_modified = { start_line = 2, end_line = 3 },
+    },
+    {
+      name = "allows a custom matcher to map a pure deletion",
+      original = { "before", "removed", "after" },
+      modified = { "before", "after" },
+      mapping = {
+        original = { start_index = 1, end_index = 2 },
+        modified = { start_index = 1, end_index = 1 },
+      },
+      expected_context = { original = { "removed" }, modified = {} },
+      expected_original = { start_line = 2, end_line = 3 },
+      expected_modified = { start_line = 2, end_line = 2 },
+    },
+  }
+
+  for _, test_case in ipairs(pure_change_cases) do
+    it(test_case.name, function()
+      local received_context
+      local result = diff.compute_diff(test_case.original, test_case.modified, {
+        line_matcher = function(matcher_context)
+          received_context = matcher_context
+          return { test_case.mapping }
+        end,
+      })
+
+      assert.same(test_case.expected_context.original, received_context.original_lines)
+      assert.same(test_case.expected_context.modified, received_context.modified_lines)
+      assert.same(test_case.expected_original, result.changes[1].line_mappings[1].original)
+      assert.same(test_case.expected_modified, result.changes[1].line_mappings[1].modified)
+    end)
+  end
 
   it("omits character changes when matching is disabled", function()
     local result = diff.compute_diff({ "old value" }, { "new value" }, {
       line_matcher = line_matchers.none,
     })
 
-    assert.same({}, result.changes[1].line_pairs)
+    assert.same({}, result.changes[1].line_mappings)
     assert.same({}, result.changes[1].inner_changes)
   end)
+
+  local invalid_mapping_cases = {
+    {
+      name = "rejects reversed ranges",
+      mappings = {
+        {
+          original = { start_index = 2, end_index = 1 },
+          modified = { start_index = 1, end_index = 2 },
+        },
+      },
+      error_pattern = "out of bounds",
+    },
+    {
+      name = "rejects out-of-bounds ranges",
+      mappings = {
+        {
+          original = { start_index = 1, end_index = 4 },
+          modified = { start_index = 1, end_index = 2 },
+        },
+      },
+      error_pattern = "out of bounds",
+    },
+    {
+      name = "rejects mappings empty on both sides",
+      mappings = {
+        {
+          original = { start_index = 1, end_index = 1 },
+          modified = { start_index = 1, end_index = 1 },
+        },
+      },
+      error_pattern = "cannot be empty on both sides",
+    },
+    {
+      name = "rejects crossing mappings",
+      mappings = {
+        one_line_mapping(1, 2),
+        one_line_mapping(2, 1),
+      },
+      error_pattern = "ordered and non%-overlapping",
+    },
+  }
+
+  for _, test_case in ipairs(invalid_mapping_cases) do
+    it(test_case.name, function()
+      local success, error_message = pcall(compute_with_mappings, test_case.mappings)
+      assert.is_false(success)
+      assert.matches(test_case.error_pattern, error_message)
+    end)
+  end
 end)

--- a/tests/core/line_matchers_spec.lua
+++ b/tests/core/line_matchers_spec.lua
@@ -1,0 +1,89 @@
+local diff = require("codediff.core.diff")
+local line_matchers = require("codediff.line_matchers")
+
+local context = {
+  original_lines = { "one", "two" },
+  modified_lines = { "ONE", "TWO" },
+  original_start_line = 4,
+  modified_start_line = 7,
+}
+
+describe("Line matchers", function()
+  local equal_line_count_cases = {
+    {
+      name = "pairs equal line counts by position",
+      context = context,
+      expected = {
+        { original_index = 1, modified_index = 1 },
+        { original_index = 2, modified_index = 2 },
+      },
+    },
+    {
+      name = "does not pair unequal line counts",
+      context = {
+        original_lines = { "one" },
+        modified_lines = { "ONE", "extra" },
+      },
+      expected = {},
+    },
+  }
+
+  for _, test_case in ipairs(equal_line_count_cases) do
+    it(test_case.name, function()
+      assert.same(test_case.expected, line_matchers.equal_line_count(test_case.context))
+    end)
+  end
+
+  it("uses a configurable similarity threshold", function()
+    local similar_context = {
+      original_lines = { "cat" },
+      modified_lines = { "cut" },
+    }
+
+    assert.same({}, line_matchers.similarity(similar_context))
+    assert.same(
+      { { original_index = 1, modified_index = 1 } },
+      line_matchers.similarity(similar_context, {
+        threshold = 0.6,
+      })
+    )
+  end)
+
+  it("returns ordered similarity pairs and leaves unrelated lines unpaired", function()
+    local pairs = line_matchers.similarity({
+      original_lines = { "local old_name = 1", "removed without match", "print(old_name)" },
+      modified_lines = { "local new_name = 1", "print(new_name)", "unrelated insertion" },
+    })
+
+    assert.same({
+      { original_index = 1, modified_index = 1 },
+      { original_index = 3, modified_index = 2 },
+    }, pairs)
+  end)
+
+  it("passes changed block context to a custom matcher", function()
+    local received_context
+    local result = diff.compute_diff({ "before", "old value", "deleted" }, { "before", "new value", "inserted" }, {
+      line_matcher = function(matcher_context)
+        received_context = matcher_context
+        return { { original_index = 1, modified_index = 1 } }
+      end,
+    })
+
+    assert.same({ "old value", "deleted" }, received_context.original_lines)
+    assert.same({ "new value", "inserted" }, received_context.modified_lines)
+    assert.equal(2, received_context.original_start_line)
+    assert.equal(2, received_context.modified_start_line)
+    assert.same({ { original_line = 2, modified_line = 2 } }, result.changes[1].line_pairs)
+    assert.is_true(#result.changes[1].inner_changes > 0)
+  end)
+
+  it("omits character changes when matching is disabled", function()
+    local result = diff.compute_diff({ "old value" }, { "new value" }, {
+      line_matcher = line_matchers.none,
+    })
+
+    assert.same({}, result.changes[1].line_pairs)
+    assert.same({}, result.changes[1].inner_changes)
+  end)
+end)

--- a/tests/core/line_matchers_spec.lua
+++ b/tests/core/line_matchers_spec.lua
@@ -138,6 +138,18 @@ describe("Line matchers", function()
     assert.is_true(#result.changes[1].inner_changes > 0)
   end)
 
+  it("preserves grouped results when batching mappings across changed blocks", function()
+    local result = diff.compute_diff({ "old alpha", "unchanged", "old beta" }, { "new alpha", "unchanged", "new beta" }, {
+      line_matcher = function()
+        return { one_line_mapping(1, 1) }
+      end,
+    })
+
+    assert.equal(2, #result.changes)
+    assert.equal(1, result.changes[1].line_mappings[1].inner_changes[1].original.start_line)
+    assert.equal(3, result.changes[2].line_mappings[1].inner_changes[1].original.start_line)
+  end)
+
   it("refines a one-to-many line mapping", function()
     local result = diff.compute_diff({ "before", "local result = prefix .. value", "after" }, { "before", "local result = prefix", "  .. value", "after" }, {
       line_matcher = function()

--- a/tests/core/vscode_parity_spec.lua
+++ b/tests/core/vscode_parity_spec.lua
@@ -1,0 +1,159 @@
+local diff = require("codediff.core.diff")
+local line_matchers = require("codediff.line_matchers")
+
+local copy_lines = function(lines)
+  local copy = {}
+  for index, line in ipairs(lines) do
+    copy[index] = line
+  end
+  return copy
+end
+
+local normalize_diff = function(result)
+  local changes = {}
+  for index, change in ipairs(result.changes) do
+    changes[index] = {
+      original = change.original,
+      modified = change.modified,
+      inner_changes = change.inner_changes,
+    }
+  end
+
+  return {
+    changes = changes,
+    moves = result.moves,
+    hit_timeout = result.hit_timeout,
+  }
+end
+
+local assert_native_parity = function(original, modified, options, message)
+  local native_options = vim.tbl_extend("force", { max_computation_time_ms = 60000 }, options or {})
+  local lua_options = vim.tbl_extend("force", native_options, { line_matcher = line_matchers.vscode })
+  local native_result = diff._compute_native_diff(original, modified, native_options)
+  local lua_result = diff.compute_diff(original, modified, lua_options)
+
+  assert.same(normalize_diff(native_result), normalize_diff(lua_result), message)
+end
+
+local generated_case = function(index)
+  local original = {}
+  local line_count = index % 8 + 1
+  for line = 1, line_count do
+    original[line] = string.format("local value_%d_%d = source_%d + %d", index, line, line * 3, index + line)
+  end
+
+  local modified = copy_lines(original)
+  if index % 2 == 0 then
+    local line = index % #modified + 1
+    modified[line] = string.format("local renamed_%d = source_%d + %d", index, line * 5, index)
+  end
+  if index % 3 == 0 then
+    local line = index % (#modified + 1) + 1
+    table.insert(modified, line, string.format("local inserted_%d = %d", index, index))
+  end
+  if index % 5 == 0 and #modified > 1 then
+    table.remove(modified, index % #modified + 1)
+  end
+  if index % 7 == 0 then
+    local line = index % #modified + 1
+    modified[line] = "  " .. modified[line] .. "  "
+  end
+  if index % 11 == 0 and #modified > 1 then
+    local line = index % (#modified - 1) + 1
+    modified[line] = modified[line] .. modified[line + 1]
+    table.remove(modified, line + 1)
+  end
+
+  return original, modified
+end
+
+describe("VS Code matcher native parity", function()
+  local test_cases = {
+    {
+      name = "empty inputs",
+      original = {},
+      modified = {},
+    },
+    {
+      name = "empty Neovim buffer insertion",
+      original = { "" },
+      modified = { "content" },
+    },
+    {
+      name = "empty Neovim buffer deletion",
+      original = { "content" },
+      modified = { "" },
+    },
+    {
+      name = "pure insertion",
+      original = { "before", "after" },
+      modified = { "before", "added", "after" },
+    },
+    {
+      name = "pure deletion",
+      original = { "before", "removed", "after" },
+      modified = { "before", "after" },
+    },
+    {
+      name = "replacement",
+      original = { "local old_name = 1" },
+      modified = { "local new_name = 1" },
+    },
+    {
+      name = "line split",
+      original = { "local result = prefix .. value" },
+      modified = { "local result = prefix", "  .. value" },
+    },
+    {
+      name = "line merge",
+      original = { "local result = prefix", "  .. value" },
+      modified = { "local result = prefix .. value" },
+    },
+    {
+      name = "multiple line merges",
+      original = { "one", "two", "three", "four" },
+      modified = { "onetwo", "threefour" },
+    },
+    {
+      name = "adjacent whitespace and line changes",
+      original = { "keep", "value", "removed", "after" },
+      modified = { "keep", "  value  ", "after" },
+    },
+    {
+      name = "unicode changes",
+      original = { "local café = '😀'" },
+      modified = { "local cafe = '😃'" },
+    },
+    {
+      name = "ignored whitespace",
+      original = { "  value" },
+      modified = { "    value  " },
+      options = { ignore_trim_whitespace = true },
+    },
+    {
+      name = "subword refinement",
+      original = { "local oldValueName = 1" },
+      modified = { "local newValueName = 1" },
+      options = { extend_to_subwords = true },
+    },
+    {
+      name = "moved code",
+      original = { "function foo()", "  return 1", "end", "", "function bar()", "  return 2", "end" },
+      modified = { "function bar()", "  return 2", "end", "", "function foo()", "  return 1", "end" },
+      options = { compute_moves = true },
+    },
+  }
+
+  for _, test_case in ipairs(test_cases) do
+    it("matches native output for " .. test_case.name, function()
+      assert_native_parity(test_case.original, test_case.modified, test_case.options)
+    end)
+  end
+
+  it("matches native output for deterministic generated edits", function()
+    for index = 1, 100 do
+      local original, modified = generated_case(index)
+      assert_native_parity(original, modified, nil, "generated case " .. index)
+    end
+  end)
+end)

--- a/tests/ui/core_spec.lua
+++ b/tests/ui/core_spec.lua
@@ -101,6 +101,34 @@ describe("Render Core", function()
     vim.api.nvim_buf_delete(right_buf, {force = true})
   end)
 
+  it("Aligns a one-to-many line mapping", function()
+    local left_buf = vim.api.nvim_create_buf(false, true)
+    local right_buf = vim.api.nvim_create_buf(false, true)
+    local original = { "local result = prefix .. value" }
+    local modified = { "local result = prefix", "  .. value" }
+
+    vim.api.nvim_buf_set_lines(left_buf, 0, -1, false, original)
+    vim.api.nvim_buf_set_lines(right_buf, 0, -1, false, modified)
+
+    local lines_diff = diff.compute_diff(original, modified, {
+      line_matcher = function()
+        return {
+          {
+            original = { start_index = 1, end_index = 2 },
+            modified = { start_index = 1, end_index = 3 },
+          },
+        }
+      end,
+    })
+    local rendered = core.render_diff(left_buf, right_buf, original, modified, lines_diff)
+
+    assert.equal(1, rendered.left_fillers)
+    assert.equal(0, rendered.right_fillers)
+
+    vim.api.nvim_buf_delete(left_buf, { force = true })
+    vim.api.nvim_buf_delete(right_buf, { force = true })
+  end)
+
   -- Test 5: Character-level diff highlights
   it("Renders character-level differences within modified lines", function()
     local left_buf = vim.api.nvim_create_buf(false, true)

--- a/tests/ui/core_spec.lua
+++ b/tests/ui/core_spec.lua
@@ -4,6 +4,7 @@
 local core = require("codediff.ui.core")
 local highlights = require("codediff.ui.highlights")
 local diff = require('codediff.core.diff')
+local line_matchers = require("codediff.line_matchers")
 
 describe("Render Core", function()
   before_each(function()
@@ -124,6 +125,29 @@ describe("Render Core", function()
 
     assert.equal(1, rendered.left_fillers)
     assert.equal(0, rendered.right_fillers)
+
+    vim.api.nvim_buf_delete(left_buf, { force = true })
+    vim.api.nvim_buf_delete(right_buf, { force = true })
+  end)
+
+  it("Aligns multiple VS Code-style line merges independently", function()
+    local left_buf = vim.api.nvim_create_buf(false, true)
+    local right_buf = vim.api.nvim_create_buf(false, true)
+    local original = { "one", "two", "three", "four" }
+    local modified = { "onetwo", "threefour" }
+
+    vim.api.nvim_buf_set_lines(left_buf, 0, -1, false, original)
+    vim.api.nvim_buf_set_lines(right_buf, 0, -1, false, modified)
+
+    local lines_diff = diff.compute_diff(original, modified, { line_matcher = line_matchers.vscode })
+    local rendered = core.render_diff(left_buf, right_buf, original, modified, lines_diff)
+    local fillers = vim.api.nvim_buf_get_extmarks(right_buf, highlights.ns_filler, 0, -1, { details = true })
+
+    assert.equal(2, rendered.right_fillers)
+    assert.equal(2, #fillers)
+    assert.same({ 0, 1 }, { fillers[1][2], fillers[2][2] })
+    assert.equal(1, #fillers[1][4].virt_lines)
+    assert.equal(1, #fillers[2][4].virt_lines)
 
     vim.api.nvim_buf_delete(left_buf, { force = true })
     vim.api.nvim_buf_delete(right_buf, { force = true })

--- a/tests/ui/inline_spec.lua
+++ b/tests/ui/inline_spec.lua
@@ -105,7 +105,7 @@ describe("Inline Diff Rendering", function()
     local buf = vim.api.nvim_create_buf(false, true)
 
     local original = { "hello world" }
-    local modified = { "hello earth" }
+    local modified = { "hello whirl" }
 
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, modified)
 
@@ -235,7 +235,7 @@ describe("Inline Diff Rendering", function()
     local buf = vim.api.nvim_create_buf(false, true)
 
     local original = { "hello world" }
-    local modified = { "hello earth" }
+    local modified = { "hello whirl" }
 
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, modified)
 


### PR DESCRIPTION
Adds configurable line-range matching for cleaner intraline highlights. Unmapped lines keep whole-line highlighting without character-level noise.

```lua
local line_matchers = require("codediff.line_matchers")

require("codediff").setup({
  diff = {
    -- Default: pair similar lines using a 0.75 threshold
    line_matcher = line_matchers.similarity,

    -- Pair no lines, leaving only whole-line highlights
    -- line_matcher = line_matchers.none,

    -- Pair more lines by lowering the similarity threshold
    -- line_matcher = function(context)
    --   return line_matchers.similarity(context, { threshold = 0.6 })
    -- end,

    -- Pair lines by position only when both sides have the same line count
    -- line_matcher = line_matchers.equal_line_count,

    -- Use CodeDiff's previous VS Code-style block refinement
    -- line_matcher = line_matchers.vscode,
  },
})
```

Custom matchers can return ordered, non-overlapping original and modified line-range mappings, including split and merge regions.

Fixes #453
