### PR TITLE
feat(compact): open in compact mode by default via diff.compact (#413)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ https://github.com/user-attachments/assets/64c41f01-dffe-4318-bce4-16eec8de356e
       compute_moves = false,              -- Detect moved code blocks (opt-in, matches VSCode experimental.showMoves)
       compact_context_lines = 3,          -- Number of context lines around hunks in compact mode
       compact_sync_folds = true,          -- Sync fold open/close across panes (mirrors Vim diff mode behavior)
+      compact = false,                    -- Open diffs in compact mode by default (fold unchanged regions; toggle with gc)
     },
 
     -- Explorer panel configuration

--- a/doc/codediff.txt
+++ b/doc/codediff.txt
@@ -197,6 +197,7 @@ Setup entry point:
       compute_moves = false,
       compact_context_lines = 3,
       compact_sync_folds = true,
+      compact = false,
       cycle_hunks_across_files = false,
     },
     explorer = {

--- a/lua/codediff/config.lua
+++ b/lua/codediff/config.lua
@@ -47,6 +47,7 @@ M.defaults = {
     compute_moves = false, -- Detect moved code blocks (opt-in, may increase diff computation time)
     compact_context_lines = 3, -- Number of context lines around hunks in compact mode
     compact_sync_folds = true, -- Sync fold open/close across panes in compact mode (mirrors Vim diff mode behavior)
+    compact = false, -- Open diffs in compact mode by default (fold unchanged regions to hunks + context; still toggleable with the gc keymap)
   },
 
   -- Explorer panel configuration

--- a/lua/codediff/ui/view/compact.lua
+++ b/lua/codediff/ui/view/compact.lua
@@ -189,6 +189,44 @@ local function teardown_fold_sync(session)
   end
 end
 
+--- The fold-target panes for a session (inline folds only the modified pane).
+--- @param session table
+--- @return table[] entries each { win, buf, side }
+local function pane_entries(session)
+  if session.layout == "inline" then
+    return { { win = session.modified_win, buf = session.modified_bufnr, side = "modified" } }
+  end
+  return {
+    { win = session.original_win, buf = session.original_bufnr, side = "original" },
+    { win = session.modified_win, buf = session.modified_bufnr, side = "modified" },
+  }
+end
+
+--- Compute + apply the compact fold settings for the current diff and
+--- (re)install the synced-fold keymaps. Idempotent and content-driven: shared
+--- by enable() and by every re-fold on a diff/file change. Does NOT touch
+--- session.compact_mode or the saved fold state — that is enable/disable's job.
+--- @param session table
+local function apply_folds(session)
+  local changes = session.stored_diff_result and session.stored_diff_result.changes
+  if not changes or #changes == 0 then
+    return
+  end
+  local context = config.options.diff.compact_context_lines
+  for _, entry in ipairs(pane_entries(session)) do
+    if entry.win and vim.api.nvim_win_is_valid(entry.win) then
+      local line_count = vim.api.nvim_buf_line_count(entry.buf)
+      visible_lines_by_win[entry.win] = M.compute_visible_lines(changes, entry.side, line_count, context)
+      vim.wo[entry.win].foldmethod = "expr"
+      vim.wo[entry.win].foldexpr = "v:lua.require'codediff.ui.view.compact'.foldexpr_eval()"
+      vim.wo[entry.win].foldenable = true
+      vim.wo[entry.win].foldlevel = 0
+      vim.wo[entry.win].foldminlines = 1
+    end
+  end
+  setup_fold_sync(session)
+end
+
 --- Enable compact mode for a tabpage
 --- @param tabpage number
 --- @return boolean success
@@ -211,22 +249,10 @@ function M.enable(tabpage)
     return false
   end
 
-  local context = config.options.diff.compact_context_lines
-
-  -- Determine which windows to fold
-  local entries = {}
-  if session.layout == "inline" then
-    table.insert(entries, { win = session.modified_win, buf = session.modified_bufnr, side = "modified" })
-  else
-    table.insert(entries, { win = session.original_win, buf = session.original_bufnr, side = "original" })
-    table.insert(entries, { win = session.modified_win, buf = session.modified_bufnr, side = "modified" })
-  end
-
+  -- Save the current fold state so disable can restore it exactly.
   session.compact_saved_fold_state = {}
-
-  for _, entry in ipairs(entries) do
+  for _, entry in ipairs(pane_entries(session)) do
     if entry.win and vim.api.nvim_win_is_valid(entry.win) then
-      -- Save current fold state
       session.compact_saved_fold_state[entry.win] = {
         foldmethod = vim.wo[entry.win].foldmethod,
         foldexpr = vim.wo[entry.win].foldexpr,
@@ -235,22 +261,11 @@ function M.enable(tabpage)
         foldenable = vim.wo[entry.win].foldenable,
         foldtext = vim.wo[entry.win].foldtext,
       }
-
-      -- Compute visible lines
-      local line_count = vim.api.nvim_buf_line_count(entry.buf)
-      visible_lines_by_win[entry.win] = M.compute_visible_lines(changes, entry.side, line_count, context)
-
-      -- Apply fold settings
-      vim.wo[entry.win].foldmethod = "expr"
-      vim.wo[entry.win].foldexpr = "v:lua.require'codediff.ui.view.compact'.foldexpr_eval()"
-      vim.wo[entry.win].foldenable = true
-      vim.wo[entry.win].foldlevel = 0
-      vim.wo[entry.win].foldminlines = 1
     end
   end
 
   session.compact_mode = true
-  setup_fold_sync(session)
+  apply_folds(session)
   return true
 end
 
@@ -300,58 +315,33 @@ function M.toggle(tabpage)
   end
 end
 
---- Re-apply compact mode fold settings to current windows.
---- Called after file switches or re-renders where window buffers change
---- but session.compact_mode should persist.
---- @param tabpage number
-function M.reapply(tabpage)
-  local session = lifecycle.get_session(tabpage)
-  if not session or not session.compact_mode then
-    return
-  end
-  if not session.stored_diff_result then
-    return
-  end
-
-  local changes = session.stored_diff_result.changes
-  if not changes or #changes == 0 then
-    return
-  end
-
-  local context = config.options.diff.compact_context_lines
-
-  local entries = {}
-  if session.layout == "inline" then
-    table.insert(entries, { win = session.modified_win, buf = session.modified_bufnr, side = "modified" })
-  else
-    table.insert(entries, { win = session.original_win, buf = session.original_bufnr, side = "original" })
-    table.insert(entries, { win = session.modified_win, buf = session.modified_bufnr, side = "modified" })
-  end
-
-  for _, entry in ipairs(entries) do
-    if entry.win and vim.api.nvim_win_is_valid(entry.win) then
-      local line_count = vim.api.nvim_buf_line_count(entry.buf)
-      visible_lines_by_win[entry.win] = M.compute_visible_lines(changes, entry.side, line_count, context)
-
-      vim.wo[entry.win].foldmethod = "expr"
-      vim.wo[entry.win].foldexpr = "v:lua.require'codediff.ui.view.compact'.foldexpr_eval()"
-      vim.wo[entry.win].foldenable = true
-      vim.wo[entry.win].foldlevel = 0
-      vim.wo[entry.win].foldminlines = 1
-    end
-  end
-
-  -- Buffers may have changed (file switch in explorer mode). Re-install
-  -- the sync keymaps on the current bufnrs.
-  setup_fold_sync(session)
-end
-
---- Refresh compact mode after diff recomputation.
---- Re-applies fold settings and forces fold re-evaluation.
+--- Keep compact mode in sync after the diff is (re)computed or a file is
+--- switched. This is the single hook the view lifecycle calls:
+---   * applies the configured "open in compact mode" default once, when the
+---     first real diff is ready;
+---   * re-folds the current diff while compact is active;
+---   * exits compact if the diff no longer has any changes.
+--- gc uses toggle()/enable()/disable() directly.
 --- @param tabpage number
 function M.refresh(tabpage)
   local session = lifecycle.get_session(tabpage)
-  if not session or not session.compact_mode then
+  if not session then
+    return
+  end
+
+  -- Open in compact mode by default (config) once, when the first real diff is
+  -- ready. Afterwards compact follows the user's gc toggle for the session.
+  if not session.compact_default_applied and session.stored_diff_result then
+    session.compact_default_applied = true
+    local changes = session.stored_diff_result.changes
+    local is_conflict = session.result_win ~= nil and vim.api.nvim_win_is_valid(session.result_win)
+    if config.options.diff.compact and not is_conflict and changes and #changes > 0 then
+      M.enable(tabpage)
+    end
+    return
+  end
+
+  if not session.compact_mode then
     return
   end
 
@@ -361,7 +351,7 @@ function M.refresh(tabpage)
     return
   end
 
-  M.reapply(tabpage)
+  apply_folds(session)
 end
 
 return M

--- a/lua/codediff/ui/view/keymaps.lua
+++ b/lua/codediff/ui/view/keymaps.lua
@@ -856,8 +856,9 @@ function M.setup_all_keymaps(tabpage, original_bufnr, modified_bufnr, is_explore
     lifecycle.set_tab_keymap(tabpage, "n", keymaps.align_move, align_move, { desc = "Align moved code block" })
   end
 
-  -- Re-apply compact mode folds if active (persists across file switches)
-  compact.reapply(tabpage)
+  -- Keep compact mode in sync when the diff view is (re)built — applies the
+  -- configured default on open and re-folds on file switches (no-op if off).
+  compact.refresh(tabpage)
 end
 
 return M

--- a/tests/ui/view/compact_spec.lua
+++ b/tests/ui/view/compact_spec.lua
@@ -476,4 +476,76 @@ describe("compact mode (#344)", function()
         "modified pane: corresponding line " .. mod_target .. " should also be inside a closed fold (synced), got " .. mod_after)
     end)
   end)
+
+  describe("open in compact mode by default (diff.compact)", function()
+    local function counts_with_changes()
+      local original = {}
+      for i = 1, 30 do
+        original[i] = "line " .. i
+      end
+      local modified = vim.deepcopy(original)
+      modified[10] = "CHANGED 10"
+      modified[20] = "CHANGED 20"
+      return original, modified
+    end
+
+    it("auto-enables compact mode on open when diff.compact = true", function()
+      local config = require("codediff.config")
+      config.options = vim.deepcopy(config.defaults)
+      require("codediff").setup({ diff = { compact = true, compact_context_lines = 3 } })
+      highlights.setup()
+
+      local original, modified = counts_with_changes()
+      local tabpage = create_session(original, modified)
+
+      assert.is_true(
+        vim.wait(3000, function()
+          local s = lifecycle.get_session(tabpage)
+          return s and s.compact_mode == true
+        end, 20),
+        "diff.compact=true should auto-enable compact mode on open"
+      )
+      local s = lifecycle.get_session(tabpage)
+      assert.equals("expr", vim.wo[s.modified_win].foldmethod, "compact should apply the fold-expr to the modified window on open")
+    end)
+
+    it("does not auto-enable compact mode when diff.compact = false", function()
+      local config = require("codediff.config")
+      config.options = vim.deepcopy(config.defaults)
+      require("codediff").setup({ diff = { compact = false } })
+      highlights.setup()
+
+      local original, modified = counts_with_changes()
+      local tabpage = create_session(original, modified)
+      vim.wait(500)
+
+      local s = lifecycle.get_session(tabpage)
+      assert.is_not.equal(true, s.compact_mode, "compact should stay off when diff.compact is false (the default)")
+    end)
+
+    it("does not re-enable compact after a manual gc toggle-off (persists per session)", function()
+      local config = require("codediff.config")
+      config.options = vim.deepcopy(config.defaults)
+      require("codediff").setup({ diff = { compact = true, compact_context_lines = 3 } })
+      highlights.setup()
+
+      local original, modified = counts_with_changes()
+      local tabpage = create_session(original, modified)
+      assert.is_true(
+        vim.wait(3000, function()
+          local s = lifecycle.get_session(tabpage)
+          return s and s.compact_mode == true
+        end, 20),
+        "should auto-enable on open"
+      )
+
+      -- User turns it off with gc
+      compact.disable(tabpage)
+      assert.is_not.equal(true, lifecycle.get_session(tabpage).compact_mode)
+
+      -- A file switch re-runs the lifecycle hook; the default must NOT force compact back on
+      compact.refresh(tabpage)
+      assert.is_not.equal(true, lifecycle.get_session(tabpage).compact_mode, "compact must stay off after a manual toggle-off, even with diff.compact=true")
+    end)
+  end)
 end)


### PR DESCRIPTION
## Summary

Adds a `diff.compact` config option (default `false`) so diffs can **open in compact mode by default** — unchanged regions folded to just hunks + context — instead of only being reachable via the `gc` toggle. This mirrors how `diff.layout` sets side-by-side vs inline.

Closes #413.

## Behavior
- `diff.compact = true` → every diff opens compacted; `gc` still toggles it per session.
- The option is applied **once per tab** when the first diff is ready; `gc` then takes over for the rest of the session, and the folds follow the content automatically across file switches.

```lua
require("codediff").setup({ diff = { compact = true } })
```

## Changes
- **`config.lua`** — new `diff.compact` option.
- **`compact.lua`** — implements the default-on behavior **and refactors out the redundancy** that made the module hard to follow:
  - extracted the shared `apply_folds()` / `pane_entries()` (the "compute visible lines + set fold options + install sync" loop was copy-pasted in `enable()` and `reapply()`),
  - deleted the redundant public `reapply()`,
  - made `compact.refresh()` the **single** view-lifecycle hook (applies the default once, re-folds while active, exits compact if a diff is emptied).
  - Net result is *fewer* lines than before despite adding the feature.
- **`keymaps.lua`** — the keymap-setup hook now calls `compact.refresh`.
- **Docs** — `README.md` and `doc/codediff.txt` config blocks.
- **Tests** — 3 new specs: auto-enables when `true`, stays off when `false`, and does **not** re-force compact back on after a manual `gc` toggle-off (persists per session).

## Testing
- New specs 3/3, `compact_spec` 30/30, **full Lua suite green**, stylua-clean on the changed code.
