### PR TITLE
fix(lifecycle): fix auto-sync path guard broken by PathRef refactor (flaky CI root cause)

### DIFF
--- a/lua/codediff/ui/lifecycle/accessors.lua
+++ b/lua/codediff/ui/lifecycle/accessors.lua
@@ -551,8 +551,11 @@ function M.setup_auto_sync_on_file_switch(tabpage, original_is_virtual, modified
     return
   end
 
-  -- Track current file path
-  local current_path = sess[working_side .. "_path"]
+  -- Session stores paths as PathRefs, so read .absolute for identity comparison.
+  -- (The old sess[working_side .. "_path"] field is gone and left this nil, which
+  -- defeated the change guard below and caused spurious re-updates.)
+  local working_ref = sess[working_side]
+  local current_path = working_ref and working_ref.absolute or nil
 
   -- Setup listener using BufWinEnter (fires when buffer enters window, even if existing buffer)
   local sync_group = vim.api.nvim_create_augroup("codediff_working_sync_" .. tabpage, { clear = true })
@@ -567,12 +570,17 @@ function M.setup_auto_sync_on_file_switch(tabpage, original_is_virtual, modified
         return
       end
 
+      local path = require("codediff.core.path")
       local new_path = vim.api.nvim_buf_get_name(args.buf)
 
       -- Skip virtual files - they're programmatic, not user navigation
       if new_path:match("^codediff://") then
         return
       end
+
+      -- Normalize to the same absolute form used for the session PathRefs so the
+      -- identity comparison is reliable across platforms.
+      new_path = new_path ~= "" and path.make_ref(new_path, nil).absolute or ""
 
       -- Check if file changed
       if new_path == "" or new_path == current_path then
@@ -599,7 +607,6 @@ function M.setup_auto_sync_on_file_switch(tabpage, original_is_virtual, modified
               end
 
               -- No pre-fetching needed, buffers will load content
-              local path = require("codediff.core.path")
               view.update(tabpage, {
                 mode = sess.mode,
                 git_root = nil,
@@ -617,7 +624,6 @@ function M.setup_auto_sync_on_file_switch(tabpage, original_is_virtual, modified
 
           -- No pre-fetching needed, buffers will load content
           vim.schedule(function()
-            local path = require("codediff.core.path")
             view.update(tabpage, {
               mode = sess.mode,
               git_root = new_git_root,


### PR DESCRIPTION
## Summary

Fixes the root cause of the intermittently failing Release/CI test `explorer_staging_spec.lua` → "should refresh staged content when index changes". This turned out to be a **real production bug** in the working-file auto-sync feature, not a test-timing issue. PR #466 only mitigated the symptom (poll harder); this fixes the actual cause.

## Root cause

The #392 path refactor replaced the session's string path fields (`original_path` / `modified_path`) with typed PathRefs (`original` / `modified`, each `{ relative, absolute }`).

`setup_auto_sync_on_file_switch` was missed by that migration — it still read the field name **dynamically**:

```lua
local current_path = sess[working_side .. "_path"]  -- sess.modified_path → now nil
```

In Lua, reading a removed table key silently returns `nil` (no error). With `current_path = nil`, the `BufWinEnter` change guard `new_path == current_path` never short-circuits. So when the real working-file buffer re-enters the working window during a rapid staged⇄changes switch, the handler fires a **spurious `view.update` using the stale session revisions**, preempting the in-flight render and leaving the view pinned to the wrong revision.

### Real-world impact
The auto-sync-on-file-switch feature (re-diff when you navigate the working pane to another file) could flicker or re-render to the wrong revision during quick view/file switching. The flaky CI test is just the reproducible symptom.

## Why it survived the refactor
It's the only reader that built the field name dynamically (`working_side .. "_path"`) — invisible to grep/LSP rename — **and** it runs in an async `BufWinEnter` autocmd that no deterministic test exercised. Every statically-named reader was correctly migrated. I audited the codebase for other instances of this class (dynamic field access, removed `*_path` reads, PathRef-as-string misuse, read-but-never-written session fields) — this was the only one.

## Fix

- Read the working file's absolute path from the PathRef: `sess[working_side].absolute`.
- Normalize the incoming buffer name via `path.make_ref(...).absolute` so the identity comparison is reliable across platforms (also closes a latent Windows backslash mismatch).

## Testing

Reproduced deterministically by pinning to one core (`taskset -c 0`), which starves the async event loop and surfaces the race:

| | Flake rate (30 runs, single-core) |
|---|---|
| Before (main) | **5 / 30** (~17%) |
| After (this PR) | **0 / 30** |

Full Lua suite (`make test-lua`) green. `stylua --check` clean.

Follow-up to #466.
