### PR TITLE
feat(builtin-compat): thin drop-in layer for Neovim built-in diff entry points

### DIFF
--- a/lua/codediff/builtin_compat.lua
+++ b/lua/codediff/builtin_compat.lua
@@ -1,0 +1,168 @@
+-- Minimal compatibility layer with Neovim's built-in diff (vimdiff).
+--
+-- codediff already provides its own engine, view, keymaps and git
+-- integration. This module only covers the built-in diff *entry points* with
+-- thin proxy commands and autocmds — no engine changes. Interface differences
+-- from built-in diff are accepted by design.
+--
+-- Provided (trivial, proxy/autocmd only):
+--   * :Diffsplit {file}  -> open a codediff of the current buffer vs {file}
+--   * :Diffoff           -> close the codediff view in the current tab
+--   * `nvim -d f1 f2`    -> open codediff at startup instead of built-in diff
+--   * 'diffopt' iwhite*  -> sync onto codediff ignore_trim_whitespace (opt-in)
+--
+-- Deliberately NOT provided here (they need real work, see commit message):
+--   * :Diffthis on an unsaved buffer, :Diffpatch, :Diffupdate, icase/algorithm
+
+local M = {}
+
+local config = require("codediff.config")
+
+local setup_done = false
+
+-- ============================================================================
+-- 'diffopt' sync (opt-in): map iwhite/iwhiteeol -> ignore_trim_whitespace.
+-- Read lazily from the current 'diffopt' value so it works regardless of
+-- whether OptionSet autocmds fire (they do not in headless contexts).
+-- ============================================================================
+function M.apply_diffopt()
+  if not config.options.builtin_compat.sync_diffopt then
+    return
+  end
+  local dip = vim.o.diffopt or ""
+  config.options.diff.ignore_trim_whitespace = dip:find("iwhite", 1, true) ~= nil
+end
+
+local function on_option_diffopt()
+  M.apply_diffopt()
+end
+
+-- ============================================================================
+-- :Diffsplit {file}
+-- Compare the current buffer with another file via codediff.
+-- ============================================================================
+local function cmd_diffsplit(opts)
+  if not config.options.builtin_compat.commands then
+    vim.notify("codediff builtin compatibility is disabled", vim.log.levels.WARN)
+    return
+  end
+
+  local target = vim.fn.expand(opts.fargs[1])
+  if target == "" then
+    vim.notify("Usage: :Diffsplit {file}", vim.log.levels.ERROR)
+    return
+  end
+
+  local current = vim.api.nvim_buf_get_name(0)
+  if current == "" or vim.bo[0].buftype ~= "" then
+    vim.notify(":Diffsplit needs a file buffer to diff from", vim.log.levels.ERROR)
+    return
+  end
+  if vim.fn.filereadable(target) ~= 1 then
+    vim.notify("File not found: " .. target, vim.log.levels.ERROR)
+    return
+  end
+
+  -- Delegate to the existing :CodeDiff file handler (lazy require: heavy).
+  M.apply_diffopt()
+  local commands = require("codediff.commands")
+  commands.vscode_diff({ fargs = { "file", current, target } })
+end
+
+-- ============================================================================
+-- :Diffoff
+-- Close the codediff view in the current tab (reuse lifecycle.close).
+-- ============================================================================
+local function cmd_diffoff()
+  local lifecycle = require("codediff.ui.lifecycle")
+  local tab = vim.api.nvim_get_current_tabpage()
+  if not lifecycle.get_session(tab) then
+    vim.notify("Not in a codediff view", vim.log.levels.INFO)
+    return
+  end
+  lifecycle.close(tab)
+end
+
+-- ============================================================================
+-- `nvim -d file1 file2` startup
+-- When Nvim was launched in diff mode with file args, open codediff instead.
+-- (Only active if this plugin is loaded at startup; e.g. not purely
+--  `cmd = "CodeDiff"` lazy-loaded.)
+-- ============================================================================
+local function on_vim_enter_nvim_d()
+  if not config.options.builtin_compat.nvim_d then
+    return
+  end
+  -- `nvim -d` turns on the 'diff' option on the startup windows.
+  if not vim.o.diff then
+    return
+  end
+
+  local argv = vim.fn.argv()
+  if #argv < 2 then
+    return
+  end
+
+  local a, b = argv[1], argv[2]
+  if vim.fn.filereadable(a) ~= 1 or vim.fn.filereadable(b) ~= 1 then
+    return
+  end
+
+  vim.schedule(function()
+    -- Do not hijack an already-running codediff session.
+    local lifecycle = require("codediff.ui.lifecycle")
+    if lifecycle.get_session(vim.api.nvim_get_current_tabpage()) then
+      return
+    end
+    -- The built-in `nvim -d` tab (may hold several diff windows) is left
+    -- behind; close it explicitly since :CodeDiff file only cleans up a
+    -- leftover single-window argv tab.
+    local builtin_tab = vim.api.nvim_get_current_tabpage()
+    M.apply_diffopt()
+    pcall(function()
+      require("codediff.commands").vscode_diff({ fargs = { "file", a, b } })
+    end)
+    vim.schedule(function()
+      local current = vim.api.nvim_get_current_tabpage()
+      if vim.api.nvim_tabpage_is_valid(builtin_tab) and builtin_tab ~= current then
+        local nr = vim.api.nvim_tabpage_get_number(builtin_tab)
+        pcall(vim.cmd, nr .. "tabclose")
+      end
+    end)
+  end)
+end
+
+-- ============================================================================
+-- Setup: register proxy commands + autocmds. Idempotent.
+-- ============================================================================
+function M.setup()
+  if setup_done then
+    return
+  end
+  setup_done = true
+
+  vim.api.nvim_create_user_command("Diffsplit", cmd_diffsplit, {
+    nargs = 1,
+    complete = "file",
+    desc = "Diff the current buffer with {file} using codediff",
+  })
+  vim.api.nvim_create_user_command("Diffoff", cmd_diffoff, {
+    nargs = 0,
+    desc = "Close the codediff view in the current tab",
+  })
+
+  local group = vim.api.nvim_create_augroup("CodeDiffBuiltinCompat", { clear = true })
+  vim.api.nvim_create_autocmd("VimEnter", {
+    group = group,
+    callback = on_vim_enter_nvim_d,
+  })
+  -- Live diffopt sync (fires in interactive Nvim; apply_diffopt is the
+  -- reliable fallback at entry points for headless/startup contexts).
+  vim.api.nvim_create_autocmd("OptionSet", {
+    pattern = "diffopt",
+    group = group,
+    callback = on_option_diffopt,
+  })
+end
+
+return M

--- a/lua/codediff/commands.lua
+++ b/lua/codediff/commands.lua
@@ -622,6 +622,11 @@ function M.vscode_merge(opts, global_opts)
 end
 
 function M.vscode_diff(opts)
+  -- Optionally sync builtin 'diffopt' (iwhite*) onto codediff options.
+  pcall(function()
+    require("codediff.builtin_compat").apply_diffopt()
+  end)
+
   -- Check if current tab is a diff view and toggle (close) it if so
   local current_tab = vim.api.nvim_get_current_tabpage()
   if lifecycle.get_session(current_tab) then

--- a/lua/codediff/config.lua
+++ b/lua/codediff/config.lua
@@ -165,6 +165,17 @@ M.defaults = {
       diffget_current = "3do", -- Get hunk from current (right/ours) buffer
     },
   },
+
+  -- Compatibility with Neovim's built-in diff (vimdiff) entry points.
+  -- Thin proxy commands / autocmds only; no engine changes.
+  builtin_compat = {
+    -- Register :Diffsplit and :Diffoff proxy commands.
+    commands = true,
+    -- Handle `nvim -d file1 file2` at startup by opening codediff.
+    nvim_d = true,
+    -- Sync 'diffopt' iwhite/iwhiteeol onto codediff ignore_trim_whitespace.
+    sync_diffopt = false,
+  },
 }
 
 M.options = vim.deepcopy(M.defaults)

--- a/plugin/codediff.lua
+++ b/plugin/codediff.lua
@@ -13,6 +13,9 @@ local virtual_file = require('codediff.core.virtual_file')
 virtual_file.setup()
 highlights.setup()
 
+-- Thin built-in-diff compatibility (proxy commands + autocmds; cheap).
+require('codediff.builtin_compat').setup()
+
 -- Re-apply highlights on ColorScheme change
 vim.api.nvim_create_autocmd("ColorScheme", {
   group = vim.api.nvim_create_augroup("CodeDiffHighlights", { clear = true }),

--- a/tests/core/builtin_compat_spec.lua
+++ b/tests/core/builtin_compat_spec.lua
@@ -1,0 +1,64 @@
+-- Tests for the built-in diff compatibility layer (codediff.builtin_compat)
+local helpers = require('tests.helpers')
+
+describe('builtin_compat', function()
+  before_each(function()
+    helpers.ensure_plugin_loaded()
+    require('codediff.builtin_compat').setup()
+  end)
+
+  describe('command registration', function()
+    it('registers :Diffsplit and :Diffoff proxy commands', function()
+      assert.equals(2, vim.fn.exists(':Diffsplit'))
+      assert.equals(2, vim.fn.exists(':Diffoff'))
+    end)
+  end)
+
+  describe('apply_diffopt (iwhite -> ignore_trim_whitespace)', function()
+    it('maps iwhite/iwhiteeol to ignore_trim_whitespace', function()
+      local config = require('codediff.config')
+      config.options.builtin_compat.sync_diffopt = true
+      local compat = require('codediff.builtin_compat')
+
+      -- Preserve the user's diffopt and restore it afterwards.
+      local saved = vim.o.diffopt
+
+      vim.o.diffopt = 'internal,filler,closeoff,iwhite'
+      compat.apply_diffopt()
+      assert.is_true(config.options.diff.ignore_trim_whitespace, 'iwhite should set ignore_trim_whitespace')
+
+      vim.o.diffopt = 'internal,filler,closeoff'
+      compat.apply_diffopt()
+      assert.is_false(config.options.diff.ignore_trim_whitespace, 'no iwhite should unset ignore_trim_whitespace')
+
+      vim.o.diffopt = saved
+    end)
+
+    it('is a no-op when sync_diffopt is disabled', function()
+      local config = require('codediff.config')
+      config.options.builtin_compat.sync_diffopt = false
+      local compat = require('codediff.builtin_compat')
+      local saved = vim.o.diffopt
+
+      config.options.diff.ignore_trim_whitespace = false
+      vim.o.diffopt = 'iwhite'
+      compat.apply_diffopt()
+      assert.is_false(config.options.diff.ignore_trim_whitespace, 'should stay unchanged when disabled')
+
+      vim.o.diffopt = saved
+    end)
+  end)
+
+  describe('command dispatch', function()
+    it('Diffoff is inert when not in a codediff view', function()
+      -- No codediff session open -> should not error, just notify.
+      local lifecycle = require('codediff.ui.lifecycle')
+      local tab = vim.api.nvim_get_current_tabpage()
+      assert.is_nil(lifecycle.get_session(tab))
+      -- Running the command should be safe (no error raised).
+      assert.has_no.errors(function()
+        vim.cmd("Diffoff")
+      end)
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary

codediff already provides its own engine, view, keymaps and git integration, so "replacing" the built-in diff (vimdiff) only requires covering its *entry points* with minimal proxy commands + autocmds. Interface differences from built-in diff are accepted by design.

## Added (trivial, proxy/autocmd only)
- `:Diffsplit {file}` — compare current buffer with `{file}` via codediff
- `:Diffoff` — close the codediff view in the current tab
- `nvim -d f1 f2` — at startup open codediff instead of built-in diff (closes the leftover built-in diff tab)
- `'diffopt' iwhite/iwhiteeol` → codediff `ignore_trim_whitespace` (opt-in), synced via `apply_diffopt()` at `CodeDiff`/`:Diffsplit` entry (reliable even where OptionSet autocmds do not fire) + an `OptionSet` autocmd for live sync
- new config section `builtin_compat { commands, nvim_d, sync_diffopt }`
- new module `lua/codediff/builtin_compat.lua`
- `tests/core/builtin_compat_spec.lua` (4 passing tests)

## Built-in diff features already covered by codediff (no change needed)
side-by-side + synced scroll; line-level DiffAdd/DiffChange/DiffDelete; char-level in-line highlighting; filler lines; folding of unchanged regions; `]c`/`[c`; `do`/`dp` + diffget/diffput; live auto-update; multi-diff per-tab sessions; git difftool/mergetool; `'diffopt'` internal, filler, context, linematch (word-level), vertical, iwhite.

## Missing (need real work, deliberately not done here)
- `:Diffthis` on an unsaved buffer (needs a buffer↔disk helper)
- `:Diffpatch {patchfile}`
- `:Diffupdate` (needs a public recompute entry point)
- `'diffopt'` icase / iwhiteall / iwhiteeol / iblank (need C-engine work)
- `'diffopt'` algorithm:{minimal,patience,histogram}, indent-heuristic
- `'diffopt'` horizontal
- `'diffopt'` closeoff / hiddenoff / foldcolumn / followwrap (different model)
- `'diffexpr'` (intentionally incompatible: codediff is the engine, not a consumer of externally-generated diffs)

## Notes
- `nvim -d` and the proxy commands require the plugin loaded at startup (not purely `cmd = "CodeDiff"` lazy).
- VimEnter/OptionSet autocmds do not fire in `nvim --headless`; diffopt sync therefore also runs at entry.
- All tests pass except a pre-existing `semantic_tokens_spec.lua` failure unrelated to this change.