### PR TITLE
fix(explorer): keep status symbol visible for long filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ https://github.com/user-attachments/assets/64c41f01-dffe-4318-bce4-16eec8de356e
       focus_on_select = false,  -- Jump to modified pane after selecting a file (default: stay in explorer)
       auto_open_on_cursor = false, -- Rebind j/k/Down/Up in the explorer to also open the file under the cursor
       status_right_margin = 1,  -- Trailing cells between status symbol (M/A/D) and right edge; increase if Nerd Font icons clip it
+      status_gap = 0, -- Minimum gap between content and the status column
       visible_groups = {       -- Which groups to show (can be toggled at runtime)
         staged = true,
         unstaged = true,

--- a/doc/codediff.txt
+++ b/doc/codediff.txt
@@ -240,6 +240,7 @@ Setup entry point:
         ignore = { ".git/**", ".jj/**" },
       },
       status_right_margin = 1,
+      status_gap = 0,
       visible_groups = {
         staged = true,
         unstaged = true,

--- a/lua/codediff/config.lua
+++ b/lua/codediff/config.lua
@@ -73,6 +73,7 @@ M.defaults = {
     auto_open_on_cursor = false, -- Rebind j/k/Down/Up in the explorer to also open the file under the cursor
     flatten_dirs = true, -- Flatten single-child directory chains in tree view (e.g., src/components/ui/)
     status_right_margin = 1, -- Trailing cells between the status symbol (M/A/D) and the right edge; increase if Nerd Font icons clip it
+    status_gap = 0, -- Minimum gap between content and the status column
     visible_groups = { -- Which groups to show in explorer (can be toggled at runtime)
       staged = true,
       unstaged = true,

--- a/lua/codediff/ui/explorer/nodes.lua
+++ b/lua/codediff/ui/explorer/nodes.lua
@@ -32,6 +32,30 @@ local STATUS_SYMBOLS = {
   ["!"] = { symbol = "!", color = "CodeDiffStatusConflict" },
 }
 
+-- Widest status symbol (e.g. "??"), so truncation aligns across all rows.
+local STATUS_SYMBOL_COLUMN_WIDTH = 0
+for _, entry in pairs(STATUS_SYMBOLS) do
+  STATUS_SYMBOL_COLUMN_WIDTH = math.max(STATUS_SYMBOL_COLUMN_WIDTH, vim.fn.strdisplaywidth(entry.symbol))
+end
+
+--- Truncate text to `keep_width` display cells, appending an ellipsis.
+local function truncate_by_width(text, keep_width)
+  local ellipsis = "…"
+  local chars_to_keep = math.max(1, keep_width - vim.fn.strdisplaywidth(ellipsis))
+
+  local byte_pos = 0
+  local accumulated_width = 0
+  for char in vim.gsplit(text, "") do
+    local char_width = vim.fn.strdisplaywidth(char)
+    if accumulated_width + char_width > chars_to_keep then
+      break
+    end
+    accumulated_width = accumulated_width + char_width
+    byte_pos = byte_pos + #char
+  end
+  return text:sub(1, byte_pos) .. ellipsis
+end
+
 -- Indent marker characters (neo-tree style)
 local INDENT_MARKERS = {
   edge = "│", -- Vertical line for non-last items
@@ -351,11 +375,11 @@ function M.prepare_node(node, max_width, selected_path, selected_group)
     -- In tree mode, don't show directory (it's in the hierarchy)
     local directory = (view_mode == "tree") and "" or full_path:sub(1, -(#filename + 1))
 
-    -- Calculate how much width we've used and reserve for status
+    -- Reserve a fixed-width status column + gap + margin, so truncation aligns across rows.
     local status_margin = config.options.explorer.status_right_margin or 1
+    local status_gap = config.options.explorer.status_gap or 0 -- gap between content and status column
     local used_width = vim.fn.strdisplaywidth(indent) + vim.fn.strdisplaywidth(icon_part)
-    -- Reserve = symbol + 2 cells of minimum gap from content + configurable trailing margin
-    local status_reserve = vim.fn.strdisplaywidth(status_symbol) + 2 + status_margin
+    local status_reserve = STATUS_SYMBOL_COLUMN_WIDTH + status_gap + status_margin
     local available_for_content = max_width - used_width - status_reserve
 
     -- Show: filename + full directory path, truncate directory from left if needed
@@ -366,26 +390,17 @@ function M.prepare_node(node, max_width, selected_path, selected_group)
     if filename_len + space_len + directory_len > available_for_content then
       -- Truncate directory from the right (keep the start)
       local available_for_dir = available_for_content - filename_len - space_len
-      if available_for_dir > 3 then
-        local ellipsis = "..."
-        local chars_to_keep = available_for_dir - vim.fn.strdisplaywidth(ellipsis)
-
-        -- Truncate directory by display width, not byte index
-        local byte_pos = 0
-        local accumulated_width = 0
-        for char in vim.gsplit(directory, "") do
-          local char_width = vim.fn.strdisplaywidth(char)
-          if accumulated_width + char_width > chars_to_keep then
-            break
-          end
-          accumulated_width = accumulated_width + char_width
-          byte_pos = byte_pos + #char
-        end
-        directory = directory:sub(1, byte_pos) .. ellipsis
+      if available_for_dir > 1 then
+        directory = truncate_by_width(directory, available_for_dir)
       else
-        -- Not enough space for directory, just show filename
+        -- Not enough space for directory, drop it entirely
         directory = ""
         space_len = 0
+
+        -- Filename alone may overflow too; truncate so the status symbol stays visible.
+        if filename_len > available_for_content then
+          filename = truncate_by_width(filename, available_for_content)
+        end
       end
     end
 
@@ -396,10 +411,11 @@ function M.prepare_node(node, max_width, selected_path, selected_group)
       line:append(directory, get_hl("ExplorerDirectorySmall"))
     end
 
-    -- Right-align status symbol; trailing `status_margin` cells keep it visible against the window edge
+    -- Status symbol right-aligned in its column (padded on the left) so "M" and "??" end flush.
     local content_len = vim.fn.strdisplaywidth(filename) + space_len + vim.fn.strdisplaywidth(directory)
-    local padding_needed = math.max(2, available_for_content - content_len + 2)
-    line:append(string.rep(" ", padding_needed), get_hl("Normal"))
+    local padding_needed = math.max(status_gap, available_for_content - content_len + status_gap)
+    local symbol_pad = STATUS_SYMBOL_COLUMN_WIDTH - vim.fn.strdisplaywidth(status_symbol)
+    line:append(string.rep(" ", symbol_pad + padding_needed), get_hl("Normal"))
     line:append(status_symbol, get_hl(data.status_color))
     if status_margin > 0 then
       line:append(string.rep(" ", status_margin), get_hl("Normal"))

--- a/tests/ui/explorer/nodes_spec.lua
+++ b/tests/ui/explorer/nodes_spec.lua
@@ -1,0 +1,134 @@
+-- Test: Explorer node formatting (status symbol visibility, truncation)
+
+local nodes = require("codediff.ui.explorer.nodes")
+local Tree = require("codediff.ui.lib.tree")
+local config = require("codediff.config")
+
+-- Build a minimal file node as prepare_node expects it (list view mode).
+local function make_file_node(path, status)
+  return Tree.Node({
+    text = path,
+    data = {
+      path = path,
+      status = status,
+      status_symbol = status,
+      status_color = "CodeDiffStatusModified",
+    },
+  })
+end
+
+-- Find the segment carrying the status symbol's highlight group.
+local function status_segment(line)
+  for _, seg in ipairs(line._segments) do
+    if seg.hl == "CodeDiffStatusModified" then
+      return seg
+    end
+  end
+  return nil
+end
+
+describe("explorer nodes: status symbol visibility", function()
+  before_each(function()
+    config.setup({ explorer = { view_mode = "list" } })
+  end)
+
+  it("keeps the status symbol visible when the filename alone is very long", function()
+    local long_name = string.rep("a", 200) .. ".lua"
+    local node = make_file_node(long_name, "M")
+
+    local line = nodes.prepare_node(node, 40, nil, nil)
+
+    local seg = status_segment(line)
+    assert.is_not_nil(seg)
+    assert.equals("M", seg.text)
+  end)
+
+  it("truncates an overly long filename with a single-cell ellipsis", function()
+    local long_name = string.rep("b", 200) .. ".lua"
+    local node = make_file_node(long_name, "M")
+
+    local line = nodes.prepare_node(node, 40, nil, nil)
+    local content = line:content()
+
+    assert.truthy(content:find("…", 1, true))
+    assert.is_false(content:find("%.%.%.", 1, false) ~= nil)
+    assert.is_false(content:find(long_name, 1, true) ~= nil)
+  end)
+
+  it("does not truncate a short filename (no regression)", function()
+    local node = make_file_node("short.lua", "M")
+
+    local line = nodes.prepare_node(node, 40, nil, nil)
+    local content = line:content()
+
+    assert.truthy(content:find("short%.lua", 1, false))
+    local seg = status_segment(line)
+    assert.is_not_nil(seg)
+    assert.equals("M", seg.text)
+  end)
+
+  it("leaves only a 1-cell gap between a maximally truncated name and the status column", function()
+    local long_name = string.rep("c", 200) .. ".lua"
+    local node = make_file_node(long_name, "M")
+
+    local line = nodes.prepare_node(node, 40, nil, nil)
+    local content = line:content()
+
+    -- "…" + symbol_pad (default gap is 0) + "M" + margin.
+    assert.truthy(content:find("… M $", 1, false))
+  end)
+
+  it("right-aligns single-char symbols within the status column (space before, not after)", function()
+    local m_node = make_file_node("short.lua", "M")
+    local untracked_node = Tree.Node({
+      text = "short.lua",
+      data = {
+        path = "short.lua",
+        status = "??",
+        status_symbol = "??",
+        status_color = "CodeDiffStatusUntracked",
+      },
+    })
+
+    local m_line = nodes.prepare_node(m_node, 40, nil, nil)
+    local untracked_line = nodes.prepare_node(untracked_node, 40, nil, nil)
+
+    -- "??" fills its column; "M" gets a 1-cell pad to end at the same column.
+    assert.equals(vim.fn.strdisplaywidth(m_line:content()), vim.fn.strdisplaywidth(untracked_line:content()))
+
+    -- "M" needs 1 extra cell of padding that "??" (already full-width) doesn't.
+    local function padding_width_before_status(line)
+      local width = 0
+      for _, seg in ipairs(line._segments) do
+        if seg.hl == "CodeDiffStatusModified" or seg.hl == "CodeDiffStatusUntracked" then
+          break
+        end
+        if seg.text:match("^%s+$") then
+          width = width + vim.fn.strdisplaywidth(seg.text)
+        end
+      end
+      return width
+    end
+
+    assert.equals(padding_width_before_status(untracked_line) + 1, padding_width_before_status(m_line))
+  end)
+
+  it("aligns the truncation point for \"??\" the same as single-char symbols", function()
+    local long_name = string.rep("d", 200) .. ".lua"
+    local modified_node = make_file_node(long_name, "M")
+    local untracked_node = Tree.Node({
+      text = long_name,
+      data = {
+        path = long_name,
+        status = "??",
+        status_symbol = "??",
+        status_color = "CodeDiffStatusUntracked",
+      },
+    })
+
+    local modified_line = nodes.prepare_node(modified_node, 40, nil, nil)
+    local untracked_line = nodes.prepare_node(untracked_node, 40, nil, nil)
+
+    assert.equals(modified_line._segments[1].text, untracked_line._segments[1].text)
+  end)
+end)


### PR DESCRIPTION
Truncates long filenames with a single-cell ellipsis so the status symbol (M/A/D/??) stays visible. Status column is now fixed-width and right-aligned across rows.

Adds status_gap config option (default 0) and covers the fix with unit tests. 