### PR TITLE
fix(conflict): close the result pane when leaving conflict mode

### DIFF
--- a/lua/codediff/ui/view/conflict_window.lua
+++ b/lua/codediff/ui/view/conflict_window.lua
@@ -70,6 +70,19 @@ function M.setup_conflict_result_window(tabpage, session_config, original_win, m
   end
 
   -- Load real file buffer in result window
+  -- `:edit` acts on the current window and fails with E37 when the buffer it
+  -- would abandon has unsaved changes -- which the result buffer always has
+  -- once auto-merged content is applied. Window creation can also leave a
+  -- different window current (win_splitmove). Pin the result window and park a
+  -- throwaway scratch in it first, so the edit can never be refused. The real
+  -- buffer is only hidden, so in-progress merge edits survive.
+  if vim.api.nvim_win_is_valid(result_win) then
+    vim.api.nvim_set_current_win(result_win)
+    if vim.bo[vim.api.nvim_get_current_buf()].modified then
+      vim.api.nvim_win_set_buf(result_win, vim.api.nvim_create_buf(false, true))
+    end
+  end
+
   -- Use silent and swapfile handling to avoid prompts
   local old_shortmess = vim.o.shortmess
   vim.o.shortmess = old_shortmess .. "A"

--- a/lua/codediff/ui/view/side_by_side.lua
+++ b/lua/codediff/ui/view/side_by_side.lua
@@ -720,6 +720,19 @@ local function show_single_file(tabpage, opts)
   -- Mark single-pane BEFORE closing window (prevents cleanup trigger)
   session.single_pane = true
 
+  -- Leaving conflict mode: close the result window too, mirroring M.update.
+  -- Without this the 3rd conflict pane survives under the single-file view, and
+  -- returning to the conflict file reuses that stale window whose buffer still
+  -- has unsaved merge edits, so `:edit` fails with E37. Closing is forced so it
+  -- also works when 'hidden' is off; the buffer only becomes hidden, never
+  -- unloaded, so in-progress merge edits are preserved.
+  local _, old_result_win = lifecycle.get_result(tabpage)
+  if old_result_win and vim.api.nvim_win_is_valid(old_result_win) then
+    vim.w[old_result_win].codediff_restore = nil
+    pcall(vim.api.nvim_win_close, old_result_win, true)
+  end
+  lifecycle.set_result(tabpage, nil, nil)
+
   -- Close the unused window
   local keep_win, close_win
   if opts.keep == "modified" then

--- a/tests/ui/conflict/conflict_file_switch_spec.lua
+++ b/tests/ui/conflict/conflict_file_switch_spec.lua
@@ -1,0 +1,149 @@
+-- Regression: leaving conflict mode must tear down the result pane.
+--
+-- In merge/conflict mode a file is shown in three panes (incoming | current on
+-- top, result below). Navigating (]f / [f) to an untracked or deleted file
+-- renders a single-pane view, which used to close only the unused input pane
+-- and leave the result window behind. The stale pane stayed under the new file,
+-- and returning to the conflict file reused that window -- whose buffer still
+-- holds unsaved merge edits -- so `:edit` failed with E37 "No write since last
+-- change" and the result pane never came back.
+
+local h = require("tests.helpers")
+local path = require("codediff.core.path")
+
+describe("conflict mode single-file switching", function()
+  local repo
+  local tabpage
+  local notify_errors
+  local saved_notify
+
+  local function conflict_config()
+    return {
+      mode = "standalone",
+      git_root = repo.dir,
+      original = path.make_ref("conf.txt", repo.dir),
+      modified = path.make_ref("conf.txt", repo.dir),
+      original_revision = ":3",
+      modified_revision = ":2",
+      conflict = true,
+    }
+  end
+
+  local function result_window()
+    local _, rw = require("codediff.ui.lifecycle").get_result(tabpage)
+    if rw and vim.api.nvim_win_is_valid(rw) then
+      return rw
+    end
+    return nil
+  end
+
+  -- Open the conflict view and wait for its three panes to exist.
+  local function open_conflict_view()
+    local view = require("codediff.ui.view")
+    local lifecycle = require("codediff.ui.lifecycle")
+
+    vim.cmd("edit " .. repo.dir .. "/conf.txt")
+    local ready = false
+    view.create(conflict_config(), "", function()
+      ready = true
+    end)
+    assert.is_true(
+      vim.wait(15000, function()
+        return ready
+      end, 50),
+      "conflict view.create did not become ready"
+    )
+
+    for _, tp in ipairs(vim.api.nvim_list_tabpages()) do
+      local s = lifecycle.get_session(tp)
+      if s and s.result_bufnr then
+        tabpage = tp
+        break
+      end
+    end
+    assert.is_not_nil(tabpage, "a conflict session should exist")
+    assert.is_not_nil(result_window(), "conflict view should have a result window")
+  end
+
+  -- Return to the conflict view the way ]f/[f does, via view.update.
+  local function reopen_conflict_view()
+    require("codediff.ui.view").update(tabpage, conflict_config(), false)
+    vim.wait(15000, function()
+      return result_window() ~= nil
+    end, 50)
+  end
+
+  before_each(function()
+    h.ensure_plugin_loaded()
+    tabpage = nil
+    repo = h.create_temp_git_repo()
+
+    repo.write_file("conf.txt", { "base1", "base2", "base3" })
+    repo.git("add -A")
+    repo.git("commit -m base")
+    repo.git("checkout -b feature")
+    repo.write_file("conf.txt", { "FEATURE1", "base2", "base3" })
+    repo.git("commit -am feature")
+    repo.git("checkout main")
+    repo.write_file("conf.txt", { "MAIN1", "base2", "base3" })
+    repo.git("commit -am main")
+    local merge_out = repo.git("merge feature --no-edit")
+    assert.is_true(merge_out:find("CONFLICT", 1, true) ~= nil, "merge must conflict")
+
+    repo.write_file("fresh.txt", { "n1", "n2" })
+
+    notify_errors = {}
+    saved_notify = vim.notify
+    vim.notify = function(msg, level, opts)
+      if type(msg) == "string" and msg:find("Failed to open result file", 1, true) then
+        notify_errors[#notify_errors + 1] = msg
+        return
+      end
+      return saved_notify(msg, level, opts)
+    end
+  end)
+
+  after_each(function()
+    if saved_notify then
+      vim.notify = saved_notify
+      saved_notify = nil
+    end
+    while vim.fn.tabpagenr("$") > 1 do
+      vim.cmd("tabclose!")
+    end
+    if repo then
+      repo.cleanup()
+      repo = nil
+    end
+  end)
+
+  it("closes the result pane when an untracked file replaces the conflict view", function()
+    open_conflict_view()
+
+    require("codediff.ui.view.side_by_side").show_untracked_file(tabpage, repo.path("fresh.txt"))
+
+    assert.is_nil(result_window(), "result pane must not survive into the single-file view")
+  end)
+
+  it("restores the conflict view without error after showing a single file", function()
+    open_conflict_view()
+    require("codediff.ui.view.side_by_side").show_untracked_file(tabpage, repo.path("fresh.txt"))
+    assert.is_nil(result_window(), "result pane must be gone while the single file is shown")
+
+    reopen_conflict_view()
+
+    assert.are.same({}, notify_errors, "returning to the conflict file must not fail to open the result file")
+    assert.is_not_nil(result_window(), "conflict result pane must be restored")
+  end)
+
+  it("keeps the result buffer loaded so merge edits are not discarded", function()
+    open_conflict_view()
+    local result_bufnr = select(1, require("codediff.ui.lifecycle").get_result(tabpage))
+    assert.is_not_nil(result_bufnr)
+
+    require("codediff.ui.view.side_by_side").show_untracked_file(tabpage, repo.path("fresh.txt"))
+
+    assert.is_true(vim.api.nvim_buf_is_valid(result_bufnr), "result buffer must stay valid")
+    assert.is_true(vim.api.nvim_buf_is_loaded(result_bufnr), "result buffer must only be hidden, never unloaded")
+  end)
+end)


### PR DESCRIPTION
## Summary

In merge/conflict mode a file is shown in three panes (incoming | current on top, **result** below). Navigating with `]f` / `[f` to an **untracked** or **deleted** file renders a single-pane view, but `show_single_file` only closed the unused *input* pane and left the **result window** behind.

Two symptoms followed:

1. The stale result pane stayed on screen underneath the newly opened file — the previous conflict file's content visibly hanging below the untracked file.
2. Navigating back to the conflict file reused that stale window. Its buffer still holds unsaved merge edits, so `:edit` was refused with `E37: No write since last change`, surfaced as **"Failed to open result file"**, and the result pane never came back.

## Root cause

`show_single_file` (`side_by_side.lua`) closes the unused original/modified window but never touched `lifecycle`'s `result_win`. The tracked-file path (`M.update`) already does exactly this cleanup, so only the single-file statuses were affected.

On return, `setup_conflict_result_window` reuses the still-registered window and runs `silent edit <file>` into it — which fails because that buffer is modified.

## Verification

A/B measured on a real merge-conflict repo, cycling conflict → single-file → conflict:

| Transition | Without fix | With fix |
|---|---|---|
| → untracked | leaked pane + `E37` | clean |
| → deleted | leaked pane + `E37` | clean |
| → tracked-modified | already clean | clean |
| **errors per run** | **2, deterministic (5/5 runs)** | **0 (8/8 runs)** |

Fixing the leak also exposed a rarer intermittent failure with the same `E37` signature, where `:edit` ran while a modified buffer was current (window creation can leave a different window focused via `win_splitmove`). That is now impossible by construction.

## Changes

- **`side_by_side.lua`** — `show_single_file` closes and clears `result_win` when leaving conflict mode, mirroring `M.update`. The buffer is only hidden, never unloaded, so in-progress merge edits survive.
- **`conflict_window.lua`** — pin the result window and park a throwaway scratch buffer before `:edit`, so loading the result file can never be refused by a modified buffer.
- **`tests/ui/conflict/conflict_file_switch_spec.lua`** — 3 regression tests: result pane torn down on switch, conflict view restored without error, and the result buffer stays loaded so merge edits are not discarded.

The new spec fails 2/3 against the unfixed code and passes 3/3 with the fix.

## Testing

Full suite green: **667 passed / 0 failed** (664 baseline + 3 new). Validated standalone on exactly this commit. All files `stylua`-formatted.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
