### PR TITLE
fix(explorer): stop idle refresh loop, preserve single-pane sizing, and fix conflict result pane

### DIFF
--- a/lua/codediff/ui/explorer/refresh.lua
+++ b/lua/codediff/ui/explorer/refresh.lua
@@ -100,6 +100,16 @@ function M.setup_auto_refresh(explorer, tabpage)
                 if watch_err then
                   return
                 end
+                -- Ignore lock files (index.lock, HEAD.lock, ...). A lock only
+                -- signals that a git operation is in flight, never that state
+                -- changed; the real change always arrives as a later write to
+                -- the target file. This also breaks a feedback loop: the
+                -- explorer's own `git status` momentarily creates index.lock,
+                -- which would otherwise wake this watcher and trigger another
+                -- status, indefinitely.
+                if filename and tostring(filename):match("%.lock$") then
+                  return
+                end
                 if not vim.api.nvim_tabpage_is_valid(tabpage) or explorer.is_hidden then
                   return
                 end

--- a/lua/codediff/ui/view/conflict_window.lua
+++ b/lua/codediff/ui/view/conflict_window.lua
@@ -70,6 +70,19 @@ function M.setup_conflict_result_window(tabpage, session_config, original_win, m
   end
 
   -- Load real file buffer in result window
+  -- `:edit` acts on the current window and fails with E37 when the buffer it
+  -- would abandon has unsaved changes -- which the result buffer always has
+  -- once auto-merged content is applied. Window creation can also leave a
+  -- different window current (win_splitmove). Pin the result window and park a
+  -- throwaway scratch in it first, so the edit can never be refused. The real
+  -- buffer is only hidden, so in-progress merge edits survive.
+  if vim.api.nvim_win_is_valid(result_win) then
+    vim.api.nvim_set_current_win(result_win)
+    if vim.bo[vim.api.nvim_get_current_buf()].modified then
+      vim.api.nvim_win_set_buf(result_win, vim.api.nvim_create_buf(false, true))
+    end
+  end
+
   -- Use silent and swapfile handling to avoid prompts
   local old_shortmess = vim.o.shortmess
   vim.o.shortmess = old_shortmess .. "A"

--- a/lua/codediff/ui/view/side_by_side.lua
+++ b/lua/codediff/ui/view/side_by_side.lua
@@ -693,6 +693,34 @@ end
 -- Single-file display (no diff) for explorer special cases
 -- ============================================================================
 
+--- True when the pane already shows exactly what this call would render.
+--- Explorer refreshes re-select the file that is already open. For real diffs
+--- on_file_select short-circuits that, but untracked/added/deleted files return
+--- before reaching its guard, so the window was torn down and rebuilt on every
+--- refresh, and the layout pass at the end of the rebuild discarded any pane
+--- the user had resized. Comparing the displayed buffer covers path and
+--- revision at once, since virtual revisions resolve to distinct buffers.
+---@param session table
+---@param opts table
+---@return boolean
+local function single_file_unchanged(session, opts)
+  if not session.single_pane then
+    return false
+  end
+  if session.single_side ~= (opts.highlight ~= false and opts.keep or nil) then
+    return false
+  end
+  local keep_win = opts.keep == "original" and session.original_win or session.modified_win
+  local other_win = opts.keep == "original" and session.modified_win or session.original_win
+  if other_win and vim.api.nvim_win_is_valid(other_win) then
+    return false
+  end
+  if not keep_win or not vim.api.nvim_win_is_valid(keep_win) then
+    return false
+  end
+  return vim.api.nvim_win_get_buf(keep_win) == opts.load_bufnr
+end
+
 --- Core implementation for showing a single file without diff.
 --- Closes the empty pane and loads the file into the remaining pane.
 ---@param tabpage number
@@ -700,6 +728,10 @@ end
 local function show_single_file(tabpage, opts)
   local session = lifecycle.get_session(tabpage)
   if not session then
+    return
+  end
+
+  if single_file_unchanged(session, opts) then
     return
   end
 

--- a/lua/codediff/ui/view/side_by_side.lua
+++ b/lua/codediff/ui/view/side_by_side.lua
@@ -752,6 +752,19 @@ local function show_single_file(tabpage, opts)
   -- Mark single-pane BEFORE closing window (prevents cleanup trigger)
   session.single_pane = true
 
+  -- Leaving conflict mode: close the result window too, mirroring M.update.
+  -- Without this the 3rd conflict pane survives under the single-file view, and
+  -- returning to the conflict file reuses that stale window whose buffer still
+  -- has unsaved merge edits, so `:edit` fails with E37. Closing is forced so it
+  -- also works when 'hidden' is off; the buffer only becomes hidden, never
+  -- unloaded, so in-progress merge edits are preserved.
+  local _, old_result_win = lifecycle.get_result(tabpage)
+  if old_result_win and vim.api.nvim_win_is_valid(old_result_win) then
+    vim.w[old_result_win].codediff_restore = nil
+    pcall(vim.api.nvim_win_close, old_result_win, true)
+  end
+  lifecycle.set_result(tabpage, nil, nil)
+
   -- Close the unused window
   local keep_win, close_win
   if opts.keep == "modified" then

--- a/tests/ui/conflict/conflict_file_switch_spec.lua
+++ b/tests/ui/conflict/conflict_file_switch_spec.lua
@@ -1,0 +1,149 @@
+-- Regression: leaving conflict mode must tear down the result pane.
+--
+-- In merge/conflict mode a file is shown in three panes (incoming | current on
+-- top, result below). Navigating (]f / [f) to an untracked or deleted file
+-- renders a single-pane view, which used to close only the unused input pane
+-- and leave the result window behind. The stale pane stayed under the new file,
+-- and returning to the conflict file reused that window -- whose buffer still
+-- holds unsaved merge edits -- so `:edit` failed with E37 "No write since last
+-- change" and the result pane never came back.
+
+local h = require("tests.helpers")
+local path = require("codediff.core.path")
+
+describe("conflict mode single-file switching", function()
+  local repo
+  local tabpage
+  local notify_errors
+  local saved_notify
+
+  local function conflict_config()
+    return {
+      mode = "standalone",
+      git_root = repo.dir,
+      original = path.make_ref("conf.txt", repo.dir),
+      modified = path.make_ref("conf.txt", repo.dir),
+      original_revision = ":3",
+      modified_revision = ":2",
+      conflict = true,
+    }
+  end
+
+  local function result_window()
+    local _, rw = require("codediff.ui.lifecycle").get_result(tabpage)
+    if rw and vim.api.nvim_win_is_valid(rw) then
+      return rw
+    end
+    return nil
+  end
+
+  -- Open the conflict view and wait for its three panes to exist.
+  local function open_conflict_view()
+    local view = require("codediff.ui.view")
+    local lifecycle = require("codediff.ui.lifecycle")
+
+    vim.cmd("edit " .. repo.dir .. "/conf.txt")
+    local ready = false
+    view.create(conflict_config(), "", function()
+      ready = true
+    end)
+    assert.is_true(
+      vim.wait(15000, function()
+        return ready
+      end, 50),
+      "conflict view.create did not become ready"
+    )
+
+    for _, tp in ipairs(vim.api.nvim_list_tabpages()) do
+      local s = lifecycle.get_session(tp)
+      if s and s.result_bufnr then
+        tabpage = tp
+        break
+      end
+    end
+    assert.is_not_nil(tabpage, "a conflict session should exist")
+    assert.is_not_nil(result_window(), "conflict view should have a result window")
+  end
+
+  -- Return to the conflict view the way ]f/[f does, via view.update.
+  local function reopen_conflict_view()
+    require("codediff.ui.view").update(tabpage, conflict_config(), false)
+    vim.wait(15000, function()
+      return result_window() ~= nil
+    end, 50)
+  end
+
+  before_each(function()
+    h.ensure_plugin_loaded()
+    tabpage = nil
+    repo = h.create_temp_git_repo()
+
+    repo.write_file("conf.txt", { "base1", "base2", "base3" })
+    repo.git("add -A")
+    repo.git("commit -m base")
+    repo.git("checkout -b feature")
+    repo.write_file("conf.txt", { "FEATURE1", "base2", "base3" })
+    repo.git("commit -am feature")
+    repo.git("checkout main")
+    repo.write_file("conf.txt", { "MAIN1", "base2", "base3" })
+    repo.git("commit -am main")
+    local merge_out = repo.git("merge feature --no-edit")
+    assert.is_true(merge_out:find("CONFLICT", 1, true) ~= nil, "merge must conflict")
+
+    repo.write_file("fresh.txt", { "n1", "n2" })
+
+    notify_errors = {}
+    saved_notify = vim.notify
+    vim.notify = function(msg, level, opts)
+      if type(msg) == "string" and msg:find("Failed to open result file", 1, true) then
+        notify_errors[#notify_errors + 1] = msg
+        return
+      end
+      return saved_notify(msg, level, opts)
+    end
+  end)
+
+  after_each(function()
+    if saved_notify then
+      vim.notify = saved_notify
+      saved_notify = nil
+    end
+    while vim.fn.tabpagenr("$") > 1 do
+      vim.cmd("tabclose!")
+    end
+    if repo then
+      repo.cleanup()
+      repo = nil
+    end
+  end)
+
+  it("closes the result pane when an untracked file replaces the conflict view", function()
+    open_conflict_view()
+
+    require("codediff.ui.view.side_by_side").show_untracked_file(tabpage, repo.path("fresh.txt"))
+
+    assert.is_nil(result_window(), "result pane must not survive into the single-file view")
+  end)
+
+  it("restores the conflict view without error after showing a single file", function()
+    open_conflict_view()
+    require("codediff.ui.view.side_by_side").show_untracked_file(tabpage, repo.path("fresh.txt"))
+    assert.is_nil(result_window(), "result pane must be gone while the single file is shown")
+
+    reopen_conflict_view()
+
+    assert.are.same({}, notify_errors, "returning to the conflict file must not fail to open the result file")
+    assert.is_not_nil(result_window(), "conflict result pane must be restored")
+  end)
+
+  it("keeps the result buffer loaded so merge edits are not discarded", function()
+    open_conflict_view()
+    local result_bufnr = select(1, require("codediff.ui.lifecycle").get_result(tabpage))
+    assert.is_not_nil(result_bufnr)
+
+    require("codediff.ui.view.side_by_side").show_untracked_file(tabpage, repo.path("fresh.txt"))
+
+    assert.is_true(vim.api.nvim_buf_is_valid(result_bufnr), "result buffer must stay valid")
+    assert.is_true(vim.api.nvim_buf_is_loaded(result_bufnr), "result buffer must only be hidden, never unloaded")
+  end)
+end)

--- a/tests/ui/explorer/explorer_spec.lua
+++ b/tests/ui/explorer/explorer_spec.lua
@@ -654,3 +654,163 @@ describe("Explorer Mode", function()
     end
   end)
 end)
+
+
+-- Two independent explorer regressions, both fixed in the file-refresh path.
+--
+-- 1. Idle refresh loop: the explorer watches .git to notice external changes,
+--    but its own `git status` momentarily writes .git/index.lock, which woke
+--    the watcher and triggered another status, indefinitely (~2 refreshes/sec
+--    while completely idle). The watcher now ignores *.lock events.
+--
+-- 2. Single-file resize reset: untracked/added/deleted files render in a single
+--    pane via show_single_file. A refresh re-selects the open file; real
+--    two-pane diffs short-circuit that, but the single-file statuses rebuilt
+--    the window every time and the layout pass discarded any manual sizing.
+--    show_single_file now skips the rebuild when nothing changed.
+describe("Explorer refresh and single-file stability", function()
+  local temp_dir
+  local original_cwd
+
+  local function open(focus_file)
+    local lifecycle = require("codediff.ui.lifecycle")
+    lifecycle.cleanup_all()
+    vim.cmd("edit " .. temp_dir .. "/" .. focus_file)
+    vim.cmd("CodeDiff")
+    local tabpage, explorer
+    local ready = vim.wait(10000, function()
+      for _, tp in ipairs(vim.api.nvim_list_tabpages()) do
+        local e = lifecycle.get_explorer(tp)
+        if e and e.winid and vim.api.nvim_win_is_valid(e.winid) then
+          tabpage, explorer = tp, e
+          return true
+        end
+      end
+      return false
+    end, 50)
+    assert.is_true(ready, "explorer should open")
+    return tabpage, explorer
+  end
+
+  local function select_and_settle(explorer, path, status, group, opts)
+    explorer.on_file_select({ path = path, status = status, group = group, git_root = temp_dir }, opts or {})
+    vim.wait(2500, function()
+      return false
+    end)
+  end
+
+  local function single_win(tabpage)
+    local lifecycle = require("codediff.ui.lifecycle")
+    local s = lifecycle.get_session(tabpage)
+    if s.original_win and vim.api.nvim_win_is_valid(s.original_win) then
+      return s.original_win
+    end
+    if s.modified_win and vim.api.nvim_win_is_valid(s.modified_win) then
+      return s.modified_win
+    end
+  end
+
+  before_each(function()
+    config.options = vim.deepcopy(config.defaults)
+    require("codediff").setup({ diff = { layout = "side-by-side" } })
+    setup_command()
+    original_cwd = vim.fn.getcwd()
+    temp_dir = vim.fn.tempname()
+    vim.fn.mkdir(temp_dir, "p")
+    vim.fn.chdir(temp_dir)
+    h.git_cmd(temp_dir, "init")
+    h.git_cmd(temp_dir, "branch -m main")
+    h.git_cmd(temp_dir, 'config user.email "test@example.com"')
+    h.git_cmd(temp_dir, 'config user.name "Test User"')
+    vim.fn.writefile({ "line 1", "line 2" }, temp_dir .. "/file1.txt")
+    h.git_cmd(temp_dir, "add file1.txt")
+    h.git_cmd(temp_dir, 'commit -m "initial"')
+    -- file1.txt modified (unstaged), file3.txt untracked
+    vim.fn.writefile({ "line 1", "line 2 modified" }, temp_dir .. "/file1.txt")
+    vim.fn.writefile({ "untracked" }, temp_dir .. "/file3.txt")
+  end)
+
+  after_each(function()
+    require("codediff.ui.lifecycle").cleanup_all()
+    vim.cmd("tabnew")
+    vim.cmd("tabonly")
+    vim.fn.chdir(original_cwd)
+    vim.wait(200)
+    if temp_dir and vim.fn.isdirectory(temp_dir) == 1 then
+      vim.fn.delete(temp_dir, "rf")
+    end
+  end)
+
+  it("does not refresh in a loop while idle", function()
+    local refresh_module = require("codediff.ui.explorer.refresh")
+    local _, explorer = open("file1.txt")
+    select_and_settle(explorer, "file1.txt", "M", "unstaged", { force = true })
+    -- Let the initial status settle so any watcher activity has drained.
+    vim.wait(1500, function()
+      return false
+    end)
+
+    local count = 0
+    local orig = refresh_module.refresh
+    refresh_module.refresh = function(e)
+      count = count + 1
+      return orig(e)
+    end
+    vim.wait(4000, function()
+      return false
+    end)
+    refresh_module.refresh = orig
+
+    -- Pre-fix this looped at roughly two refreshes per second off the explorer's
+    -- own index.lock writes.
+    assert.are.equal(0, count, "explorer must stay quiescent while idle, got " .. count)
+  end)
+
+  it("keeps a manually resized single-file pane across a refresh", function()
+    local tabpage, explorer = open("file1.txt")
+    select_and_settle(explorer, "file3.txt", "??", "unstaged", { force = true })
+
+    local win = single_win(tabpage)
+    assert.is_not_nil(win, "untracked file should be shown in a single pane")
+    local width = vim.api.nvim_win_get_width(win) - 10
+    vim.api.nvim_win_call(win, function()
+      vim.cmd("vertical resize " .. width)
+    end)
+    assert.are.equal(width, vim.api.nvim_win_get_width(win), "resize should apply")
+
+    -- A refresh re-selects the file that is already open.
+    select_and_settle(explorer, "file3.txt", "??", "unstaged")
+
+    assert.are.equal(width, vim.api.nvim_win_get_width(single_win(tabpage)), "manual pane size must survive a refresh")
+  end)
+
+  it("still re-renders a single-file view when the file's status changes", function()
+    local tabpage, explorer = open("file1.txt")
+    select_and_settle(explorer, "file3.txt", "??", "unstaged", { force = true })
+    local before = vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(single_win(tabpage)))
+
+    -- Staging turns ?? into A, shown from the index (:0) rather than the working
+    -- tree, so the view must rebuild rather than be skipped.
+    h.git_cmd(temp_dir, "add file3.txt")
+    select_and_settle(explorer, "file3.txt", "A", "staged")
+
+    local after = vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(single_win(tabpage)))
+    assert.are_not.equal(before, after, "staged view must come from a different buffer than the working-tree view")
+  end)
+
+  it("still restores both panes when returning to a real diff", function()
+    local tabpage, explorer = open("file1.txt")
+    select_and_settle(explorer, "file3.txt", "??", "unstaged", { force = true })
+    assert.is_not_nil(single_win(tabpage), "should be in single-pane mode")
+
+    select_and_settle(explorer, "file1.txt", "M", "unstaged", { force = true })
+
+    local lifecycle = require("codediff.ui.lifecycle")
+    local s = lifecycle.get_session(tabpage)
+    assert.is_true(
+      s.original_win ~= nil and vim.api.nvim_win_is_valid(s.original_win) and s.modified_win ~= nil and vim.api.nvim_win_is_valid(s.modified_win),
+      "returning to a modified file must restore both diff panes"
+    )
+  end)
+end)
+


### PR DESCRIPTION
## Summary

Three fixes across the diff explorer and conflict view, in two commits.

## 1. Explorer: idle refresh loop + single-pane resize reset (`a8a553e`)

Two independent bugs, both in the file-refresh path.

**Idle refresh loop.** With the explorer open, codediff refreshed roughly **twice a second, forever** — even completely idle (measured ~20 refreshes / 10s, flat with no decay, each spawning a `git` process and re-rendering).

Root cause is a self-inflicted feedback loop: the explorer watches `.git` to notice external changes, but its own `git status` momentarily writes `.git/index.lock`, which wakes the watcher, which runs `git status` again, indefinitely.

Fix: ignore `*.lock` events in the watcher. A lock file only signals that a git operation is in flight, never that state changed — the real change always arrives as a later write to the target file.

Measured after the fix:

| | before | after |
|---|---|---|
| idle refreshes / 10s | ~20 | **0** |
| idle `git` subprocesses / min | ~120 | **0** |
| idle nvim CPU / 10s | ~290 ms | ~6 ms |
| real change (`git add`) detected | yes | **yes (1 refresh)** |

**Single-pane resize reset.** Untracked / added / deleted files render in a single pane via `show_single_file`. A refresh re-selects the open file; real two-pane diffs short-circuit that in `on_file_select`, but the single-file statuses returned earlier and rebuilt the window every time — and the layout pass at the end of the rebuild discarded any manual pane sizing. So resizing an A/D/untracked pane snapped back to default within ~half a second.

Fix: `show_single_file` skips the rebuild when the pane already shows exactly what would be rendered, mirroring the guard two-pane diffs already had. Content updates and status changes (`??` → `A`) still re-render; returning to a real diff still restores both panes.

## 2. Conflict: close the result pane when leaving conflict mode (`7e4efae`)

In merge/conflict mode a file is shown in three panes (incoming | current on top, result below). Navigating with `]f` / `[f` to an untracked or deleted file rendered a single-pane view, but `show_single_file` only closed the unused input pane and left the result window behind.

Two symptoms: the stale result pane stayed on screen under the new file, and returning to the conflict file reused that window — whose buffer still holds unsaved merge edits — so `:edit` failed with `E37: No write since last change` and the result pane never came back.

Fix: `show_single_file` closes and clears `result_win` when leaving conflict mode (mirroring `M.update`), and `setup_conflict_result_window` pins the result window and parks a scratch buffer before `:edit`, so loading the result file can never be refused by a modified buffer (this also closed a rarer race with the same signature).

Verified by A/B run: without the fix the untracked and deleted transitions leak the pane and raise 2 errors per run (deterministic); with it, 0 across repeated runs.

## Testing

- **P1** — new test asserts the explorer stays quiescent (0 refreshes) over an idle window.
- **P2** — new tests: resized single-file pane survives a refresh; a status change still re-renders; returning to a real diff restores both panes.
- **Conflict** — result pane torn down on switch, conflict view restored without error, result buffer only hidden so merge edits survive.

Each new test was confirmed to **fail against the unfixed code** and pass with the fix.

Full suite: **671 passed / 0 failed**.

## Notes

The single-pane fix covers the side-by-side path (`side_by_side.lua`). Inline mode has its own `show_single_file` that was not in scope here.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
