### PR TITLE
Skip explorer refresh when status is unchanged; fix stale on_file_select race

### DIFF
--- a/lua/codediff/ui/explorer/refresh.lua
+++ b/lua/codediff/ui/explorer/refresh.lua
@@ -202,6 +202,17 @@ function M.refresh(explorer)
         return
       end
 
+      -- Skip the whole downstream refresh (tree rebuild, re-selection,
+      -- mutable-buffer sync) when the status is identical to the previous
+      -- tick. `git status` still runs every tick so coverage is unchanged;
+      -- this only avoids UI churn (tree re-render, re-selection re-running
+      -- layout.arrange, extmark rewrites) that would flicker the interface
+      -- and can interrupt the user (manual pane sizes reset, tree flatten
+      -- flake, cursor jumps) even though nothing actually changed.
+      if vim.deep_equal(status_result, explorer.status_result) then
+        return
+      end
+
       -- Rebuild tree nodes (honors group visibility) and re-render.
       rebuild_tree(explorer, status_result, collapsed_state)
 

--- a/lua/codediff/ui/explorer/render.lua
+++ b/lua/codediff/ui/explorer/render.lua
@@ -234,6 +234,9 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
       end
 
       vim.schedule(function()
+        if explorer.current_file_path ~= file_path then
+          return
+        end
         ---@type SessionConfig
         local session_config = {
           mode = "explorer",
@@ -253,6 +256,9 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
     -- Handle untracked files: show file without diff
     if file_data.status == "??" then
       vim.schedule(function()
+        if explorer.current_file_path ~= file_data.path then
+          return
+        end
         local sess = lifecycle.get_session(tabpage)
         if sess and sess.layout == "inline" then
           require("codediff.ui.view.inline_view").show_single_file(tabpage, abs_path, {
@@ -268,6 +274,9 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
     -- Handle added files: only one side has the file
     if file_data.status == "A" then
       vim.schedule(function()
+        if explorer.current_file_path ~= file_data.path then
+          return
+        end
         local sess = lifecycle.get_session(tabpage)
         local is_inline = sess and sess.layout == "inline"
 
@@ -309,6 +318,9 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
     -- Handle deleted files: show old content without diff
     if file_data.status == "D" then
       vim.schedule(function()
+        if explorer.current_file_path ~= file_data.path then
+          return
+        end
         local sess = lifecycle.get_session(tabpage)
         local is_inline = sess and sess.layout == "inline"
 
@@ -396,6 +408,10 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
     if base_revision and target_revision and target_revision ~= "WORKING" then
       -- Two revision mode: Compare base vs target
       vim.schedule(function()
+        -- Ignore stale async: see comment on the base_revision branch below.
+        if explorer.current_file_path ~= file_path then
+          return
+        end
         ---@type SessionConfig
         local session_config = {
           mode = "explorer",
@@ -423,6 +439,13 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
       if base_revision then
         -- Revision mode: Simple comparison of working tree vs base_revision
         vim.schedule(function()
+          -- Ignore stale async: if a newer selection superseded us before this
+          -- scheduled callback ran, `view.update` on the old target would
+          -- clobber the newer selection (buffers get swapped, virtual buffers
+          -- with `bufhidden=wipe` get destroyed mid-load, single_pane resets).
+          if explorer.current_file_path ~= file_path then
+            return
+          end
           ---@type SessionConfig
           local session_config = {
             mode = "explorer",
@@ -438,6 +461,10 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
         -- Merge conflict: Show incoming (:3) vs current (:2), both diffed against base (:1)
         -- Position controlled by config.diff.conflict_ours_position (absolute screen position)
         vim.schedule(function()
+          -- Ignore stale async: see comment on the base_revision branch above.
+          if explorer.current_file_path ~= file_path then
+            return
+          end
           -- Determine conflict buffer positions based on config
           -- conflict_ours_position controls where :2 (OURS) appears on screen
           local ours_position = config.options.diff.conflict_ours_position or "right"
@@ -471,6 +498,10 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
         -- For renames: old_path in HEAD, new path in staging
         -- No pre-fetching needed, virtual files will load via BufReadCmd
         vim.schedule(function()
+          -- Ignore stale async: see comment on the base_revision branch above.
+          if explorer.current_file_path ~= file_path then
+            return
+          end
           ---@type SessionConfig
           local session_config = {
             mode = "explorer",
@@ -499,6 +530,12 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
 
         -- No pre-fetching needed, buffers will load content
         vim.schedule(function()
+          -- Ignore stale async: if a newer selection superseded us before this
+          -- scheduled callback ran, `view.update` on the old target would
+          -- clobber the newer one (resetting single_pane, layout.arrange).
+          if explorer.current_file_path ~= file_path then
+            return
+          end
           ---@type SessionConfig
           local session_config = {
             mode = "explorer",


### PR DESCRIPTION
Two related changes in the explorer refresh path.

## 1. Skip refresh when status is unchanged (`refresh.lua`, +11 LOC)

The 500ms polling introduced by #483 always ran the full downstream refresh — tree rebuild + re-selection + `sync_mutable_buffers` — on every tick, even when `git status`'s output hadn't changed since the last tick. That produces steady UI churn (tree re-render, extmark rewrites) and interrupts users (manual pane sizes reset, tree-flatten flicker, cursor jumps) with no observable benefit.

Fix: `vim.deep_equal(status_result, explorer.status_result)` early-return.

- `git status` still runs every tick — **coverage is unchanged**.
- We only skip UI work that produces the same output as before.
- ~2ms per idle tick saved on typical repos; much more on large repos where tree rebuild dominates.

## 2. Guard on_file_select against stale scheduled callbacks (`render.lua`, +37 LOC across 8 sites)

The optimization above exposed a pre-existing async race that polling was masking.

**The race.** `on_file_select` schedules its diff-view swap via `vim.schedule`. When two selections queue in quick succession (e.g. focus_file auto-select racing with a user click), both scheduled callbacks fire in order — the stale one runs `view.update` on the old file, swapping buffers in the pane, wiping the newer virtual buffer via `bufhidden=wipe` (which drops any in-flight async content load), resetting `layout.arrange`, and clearing `session.single_pane`.

Polling had been running `on_file_select` for the current file ~2×/s, silently re-establishing the correct state within 500ms — so users saw at most a brief flicker. Once we skip the polling, the race becomes durable — the wrong file's content stays on screen until the user clicks again.

**Fix.** At every `vim.schedule` block in `on_file_select`, check whether the current selection has moved on before doing any work:

```lua
vim.schedule(function()
  if explorer.current_file_path ~= file_path then
    return
  end
  -- ...actual work...
end)
```

`explorer.current_file_path` is set synchronously by the outer wrapper on every selection, so by the time a stale callback runs, the mismatch is authoritative. Applied to all 8 schedule sites: dir mode, `??`/`A`/`D` single-pane paths, two-revision, `base_revision` single-rev, conflicts, staged.

The guard is a targeted fix at each choke point, not an architectural cancellation model — it's correct on its own, plays cleanly with any future cancellation architecture (redundant under it, never wrong), and matches the idiom used elsewhere in the async ecosystem (React `isMounted`, LSP request IDs).

## Verified

- `explorer_spec.lua`: **21/21** (5× runs, zero flake). Includes the `#480` regression guards for the manual resize + external `touch` detection.
- `issue_390_spec.lua`: **1/1** (3× runs, zero flake). Deleted-file content in revision mode.
- Full `make test-lua`: **751 pass / 0 fail**.
- `stylua --check` clean on both changed files.

## Why the two changes ship together

The refresh skip alone would leave the stale-selection race producing user-visible bugs (broke `issue_390_spec` when tested in isolation). The guard fixes the race regardless of the optimization. Shipping them together closes both.
