### PR TITLE
ci: align Copilot cloud agent env with local CLI experience

### DIFF
--- a/.github/instructions/build.instructions.md
+++ b/.github/instructions/build.instructions.md
@@ -1,9 +1,5 @@
-applyTo:
-  - "**/CMakeLists.txt"
-  - Makefile
-  - Makefile.win
-  - build.cmd
-  - build.sh
+---
+applyTo: "**/CMakeLists.txt,Makefile,Makefile.win,build.cmd,build.sh"
 ---
 
 # Build System Files

--- a/.github/instructions/dev-docs.instructions.md
+++ b/.github/instructions/dev-docs.instructions.md
@@ -1,5 +1,5 @@
-applyTo:
-  - docs/development/**
+---
+applyTo: "docs/development/**"
 ---
 
 # Development Documentation Guidelines

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,5 +1,5 @@
-applyTo:
-  - docs/**
+---
+applyTo: "docs/**"
 ---
 
 # Documentation Guidelines

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,5 +1,5 @@
-applyTo:
-  - tests/**
+---
+applyTo: "tests/**"
 ---
 
 # Test Directory Guidelines

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -47,10 +47,10 @@ jobs:
             artifact: windows-arm64
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 'lts/*'
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 'lts/*'
 
@@ -33,11 +33,49 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential cmake
 
-      - name: Setup Neovim
-        uses: ./.github/actions/setup-neovim
+      # Cache Neovim between coding-agent sessions to skip the ~10-15s download.
+      # We install inline into $HOME/nvim instead of using ./.github/actions/setup-neovim,
+      # which writes to root-owned /usr/local (not restorable by actions/cache without sudo).
+      # Other CI workflows continue to use the composite action unchanged.
+      # Bump the trailing key suffix (e.g. -v1 -> -v2) to force a fresh nightly.
+      - name: Cache Neovim
+        id: cache-neovim
+        uses: actions/cache@v5
+        with:
+          path: ~/nvim
+          key: neovim-nightly-${{ runner.os }}-${{ runner.arch }}-v1
 
-      # Note: plenary.nvim and nui.nvim are installed on-demand by tests/init.lua
-      # This keeps behavior consistent with the main CI pipeline
+      - name: Install Neovim
+        if: steps.cache-neovim.outputs.cache-hit != 'true'
+        run: |
+          NVIM_ARCH="linux-x86_64"
+          [ "$(uname -m)" = "aarch64" ] && NVIM_ARCH="linux-arm64"
+          mkdir -p "$HOME/nvim"
+          curl -fsSL "https://github.com/neovim/neovim/releases/download/nightly/nvim-${NVIM_ARCH}.tar.gz" \
+            | tar xz -C "$HOME/nvim" --strip-components=1
+
+      - name: Add Neovim to PATH
+        run: |
+          echo "$HOME/nvim/bin" >> "$GITHUB_PATH"
+          "$HOME/nvim/bin/nvim" --version | head -n 1
+
+      # Preinstall plenary.nvim so the coding agent doesn't need github.com at task time.
+      # tests/init.lua expects it under vim.fn.stdpath("data")/plenary.nvim, which on
+      # Linux resolves to $HOME/.local/share/nvim/plenary.nvim.
+      # nui.nvim is not a runtime or test dependency (verified: zero require("nui...") in lua/).
+      - name: Cache plenary.nvim
+        id: cache-plenary
+        uses: actions/cache@v5
+        with:
+          path: ~/.local/share/nvim/plenary.nvim
+          key: plenary-nvim-${{ runner.os }}-v1
+
+      - name: Install plenary.nvim
+        if: steps.cache-plenary.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p "$HOME/.local/share/nvim"
+          git clone --depth=1 https://github.com/nvim-lua/plenary.nvim \
+            "$HOME/.local/share/nvim/plenary.nvim"
 
       - name: Build native library
         run: make build
@@ -45,6 +83,3 @@ jobs:
       - name: Verify Neovim can load the plugin
         run: |
           nvim --headless -u tests/init.lua -c "lua print('codediff version: ' .. require('codediff.version').VERSION)" -c "qa!"
-
-      - name: Run tests to verify environment
-        run: ./tests/run_plenary_tests.sh

--- a/.github/workflows/regression-check.yml
+++ b/.github/workflows/regression-check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Need full history to compare branches
       
@@ -33,7 +33,7 @@ jobs:
       
       - name: Set up Node.js
         if: steps.check-changes.outputs.has_changes == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 'lts/*'
       

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,14 +35,14 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}
           ref: ${{ github.ref_name }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 'lts/*'
 
@@ -130,7 +130,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/standalone-build-test.yml
+++ b/.github/workflows/standalone-build-test.yml
@@ -42,7 +42,7 @@ jobs:
             openmp: true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install OpenMP (Ubuntu)
         if: matrix.os == 'ubuntu-latest' && matrix.openmp


### PR DESCRIPTION
## Summary

Aligns the GitHub Copilot **cloud coding agent** environment with the local CLI experience. Four independent parity improvements bundled together because they all target the same failure mode: cloud sessions starting with a slower / less accurate environment than local.

## Changes

### 1. Repo-wide `@v4 → @v5` bump — 5 workflows
`build-and-test.yml`, `copilot-setup-steps.yml`, `regression-check.yml`, `release.yml`, `standalone-build-test.yml` — all pinned `actions/checkout`, `actions/setup-node`, `actions/cache` uses moved to `@v5` for consistency with the versions documented in the Copilot coding-agent setup docs.

### 2. Fix `.instructions.md` frontmatter (4 files) — **verified real bug**
Before: opening `---` delimiter was missing. Verified against both reference parsers:

| Parser | metadata extracted |
|---|---|
| `gray-matter` (JS) | `{}` ❌ |
| `python-frontmatter` (Python) | `{}` ❌ |

Consequence: `applyTo` scoping silently ignored on GitHub.com, **and** the raw `applyTo:` block leaked as plain text into the local CLI's context. Fixed to the docs-mandated comma-separated string form:

```yaml
---
applyTo: "tests/**"
---
```

Post-fix, both parsers return the correct `applyTo` value.

### 3. Remove full test-suite from `copilot-setup-steps.yml`
Kept the ~1s "Verify Neovim can load the plugin" smoke test as a minimal sanity check. Removed the `./tests/run_plenary_tests.sh` step because:
- Local CLI never runs the test suite at startup.
- Per GitHub docs: "If any setup step fails by returning a non-zero exit code, Copilot will skip the remaining setup steps and begin working with the current state of its development environment." A flaky test on `main` today silently degrades every cloud-agent session.
- Saves ~30–60s per cold start.
- The agent will still run tests itself when the task requires.

### 4. Preinstall `plenary.nvim` (with cache) + inline Neovim install for caching
`tests/init.lua` clones `plenary.nvim` from `github.com/nvim-lua/plenary.nvim` on first test run. On the ephemeral cloud runner that happens every session and depends on runtime firewall access. Preinstalling matches "local already has it".

Also inlined the Neovim install in `copilot-setup-steps.yml` only. The shared `./.github/actions/setup-neovim` composite writes to root-owned `/usr/local`, which `actions/cache` cannot restore without sudo tar tricks. The other 4 workflows continue to use the composite action unchanged.

**Verified `nui.nvim` is NOT a dependency** despite a stale comment in the old workflow — zero `require("nui...")` in `lua/`, and `tests/init.lua` never clones it. The only match in the repo is a comment inside a single test spec. Not installed.

## Benefits

Net effect on Copilot cloud agent sessions after the first:
- **~10–15s faster startup** (cached Neovim + cached plenary)
- **No runtime `github.com` dependency** for plenary clone
- **No session degradation** from flaky-test failures during setup
- **Path-scoped instructions actually apply** as designed

Local CLI also benefits from item 2 — the frontmatter no longer leaks into its context, and scoping starts working.

## Testing

- YAML syntax: all 6 workflow files parse under `python3 -c "import yaml; yaml.safe_load(open(f))"`
- Frontmatter: all 4 `.instructions.md` files pass `assert 'applyTo' in post.metadata` under `python-frontmatter`
- Inline Neovim install: locally verified `curl … | tar xz -C $HOME/nvim --strip-components=1` produces a working `$HOME/nvim/bin/nvim` binary
- Trailing whitespace introduced by this PR: none (pre-existing whitespace in `regression-check.yml` on unrelated lines was not touched)

## Non-goals

Deliberately did NOT:
- Add `.github/copilot-instructions.md` — repo doesn't have one locally, adding it would create divergence
- Add MCP config or `copilot` environment secrets — not present locally
- Modify `AGENTS.md`, `CLAUDE.md`, or the `.github/actions/setup-neovim/` composite action's contract
- Add a larger runner (out of scope; needs org-level runner configuration)
- Cache apt (`build-essential`, `cmake` are pre-installed on `ubuntu-latest`; near-noop) or `setup-node` npm cache (no `package.json` in repo)
