### PR TITLE
fix(explorer): re-render on `toggle_view_mode` after #486 skip regression

### DIFF
--- a/lua/codediff/ui/explorer/actions.lua
+++ b/lua/codediff/ui/explorer/actions.lua
@@ -168,8 +168,11 @@ function M.toggle_view_mode(explorer)
   -- Update config
   config.options.explorer.view_mode = new_mode
 
-  -- Refresh to rebuild tree with new mode
-  refresh_module.refresh(explorer)
+  -- View-mode change is client-only: git status is unchanged, so the async
+  -- refresh() path would hit the deep_equal skip introduced in #486 and
+  -- silently no-op. Rebuild synchronously from the cached status instead
+  -- (same pattern as toggle_group) so the new mode takes effect immediately.
+  refresh_module.rebuild_from_cache(explorer)
 
   vim.notify("Explorer view: " .. new_mode, vim.log.levels.INFO)
 end

--- a/tests/ui/explorer/explorer_spec.lua
+++ b/tests/ui/explorer/explorer_spec.lua
@@ -433,6 +433,30 @@ describe("Explorer Mode", function()
     assert_first_visible_file_selected(explorer, session, "nested/deep.txt")
   end)
 
+  it("Re-renders the explorer buffer when toggle_view_mode flips the mode (regression #486)", function()
+    -- PR #486 added a "skip refresh when git status unchanged" optimization at
+    -- refresh.lua that made toggle_view_mode a no-op: view_mode is a client-only
+    -- config, so flipping it never changes git status, and the deep_equal skip
+    -- fired before the tree got rebuilt. Fix: toggle_view_mode now uses
+    -- rebuild_from_cache (like toggle_group) instead of the async refresh path.
+    local explorer = open_initial_explorer(temp_dir, "list")
+    local before_lines = vim.api.nvim_buf_get_lines(explorer.bufnr, 0, -1, false)
+    local before_mode = config.options.explorer.view_mode
+
+    require("codediff.ui.explorer.actions").toggle_view_mode(explorer)
+    vim.wait(200)
+
+    local after_lines = vim.api.nvim_buf_get_lines(explorer.bufnr, 0, -1, false)
+    local after_mode = config.options.explorer.view_mode
+
+    assert.equals("list", before_mode)
+    assert.equals("tree", after_mode)
+    assert.is_false(
+      vim.deep_equal(before_lines, after_lines),
+      "Explorer buffer must re-render when view_mode flips (bug: skip check swallowed the rebuild)"
+    )
+  end)
+
   it("Does not select files excluded from the explorer", function()
     local explorer, session = open_initial_explorer(temp_dir, "list", { "file1.txt", "file3.txt" })
     assert_first_visible_file_selected(explorer, session, "nested/deep.txt")


### PR DESCRIPTION
## Summary

Pressing `i` in the explorer to toggle between list and tree view silently no-ops: the config flips from `"list"` to `"tree"`, but the buffer stays in the old layout.

## Root cause — regression from #486

PR #486 (876d269, "Skip explorer refresh when status is unchanged; fix stale on_file_select race") added a `vim.deep_equal(status_result, explorer.status_result)` short-circuit inside `refresh()` at `lua/codediff/ui/explorer/refresh.lua:212` to avoid UI churn on the 500 ms poll when `git status` hadn't changed.

Correct for its intended scope (the poll and the manual `R` refresh). Wrong for **client-only state changes** that must trigger a rebuild — `view_mode` is a config toggle, so `git status` is by definition unchanged, so the skip fires before the tree is rebuilt.

Isolation probe: reverting **only** the deep_equal skip (and leaving `refresh()` as the call) also re-renders correctly, which rules out any timing or scheduling explanation and pins the cause precisely on the skip check.

## Fix

`toggle_view_mode` at `actions.lua:174` now uses `refresh_module.rebuild_from_cache` instead of `refresh_module.refresh`, mirroring the pattern `toggle_group` already uses for the analogous "visibility changed, git status did not" case at `actions.lua:190`. This bypasses the deep_equal skip via a different code path, rebuilds the tree synchronously from the cached status, and also elides an unnecessary async `git status` call.

```diff
- -- Refresh to rebuild tree with new mode
- refresh_module.refresh(explorer)
+ -- View-mode change is client-only: git status is unchanged, so the async
+ -- refresh() path would hit the deep_equal skip introduced in #486 and
+ -- silently no-op. Rebuild synchronously from the cached status instead
+ -- (same pattern as toggle_group) so the new mode takes effect immediately.
+ refresh_module.rebuild_from_cache(explorer)
```

## Comprehensive audit — no other regressions of this shape

Traced every possible victim of the same anti-pattern in the codebase:

- **Only one `deep_equal` short-circuit exists in the entire plugin** (the #486 one at `explorer/refresh.lua:212`). `history/refresh.lua` has no such check.
- All other callers of `refresh_module.refresh` are safe by design: they exist to detect genuine git-status changes (the 500 ms poll and the manual `R` keymap), so a no-op skip is the *correct* behavior when nothing changed.
- All runtime writes to `config.options.explorer.*` and `explorer.visible_groups` other than `toggle_view_mode` already use `rebuild_from_cache` (`toggle_group`) or a bespoke rebuild (history's own `toggle_view_mode`).
- The 9 stale-selection guards in `render.lua` (the other half of #486) were re-verified: the wrapper sets `current_file_path` synchronously *before* scheduling the guarded callbacks, so no legitimate flow bails out spuriously.

## Regression test

`tests/ui/explorer/explorer_spec.lua`:

```lua
it("Re-renders the explorer buffer when toggle_view_mode flips the mode (regression #486)", function()
  local explorer = open_initial_explorer(temp_dir, "list")
  local before_lines = vim.api.nvim_buf_get_lines(explorer.bufnr, 0, -1, false)
  local before_mode = config.options.explorer.view_mode

  require("codediff.ui.explorer.actions").toggle_view_mode(explorer)
  vim.wait(200)

  local after_lines = vim.api.nvim_buf_get_lines(explorer.bufnr, 0, -1, false)
  local after_mode = config.options.explorer.view_mode

  assert.equals("list", before_mode)
  assert.equals("tree", after_mode)
  assert.is_false(vim.deep_equal(before_lines, after_lines))
end)
```

Fail-before / pass-after verified: temporarily reverting the source fix left the same test as the only failure (1/22 failed, exactly the new test).

## Testing

- `plenary` on `explorer_spec.lua` — **22/22 pass** with the fix; **21 pass / 1 fail** with the source fix reverted.
- `stylua --check` on the touched Lua file (`actions.lua`) — clean.
- Manual repro (nvim-e2e headless scenario) confirmed the visible flip from flat list to nested tree.

## No version bump

Per user direction — small, self-contained fix with regression coverage.
