### PR TITLE
feat(ci): Termux support (Android arm64 + x64) + per-platform CI templates

### DIFF
--- a/.github/workflows/_platform-android.yml
+++ b/.github/workflows/_platform-android.yml
@@ -57,8 +57,10 @@ jobs:
             -DANDROID_PLATFORM=android-24 \
             -DENABLE_OPENMP=OFF \
             -DCMAKE_BUILD_TYPE=Release
-          cmake --build build-android --target vscode-diff -j
-          cp build-android/libvscode-diff/libvscode_diff.so ./libvscode_diff.so
+          cmake --build build-android --target vscode_diff -j
+          # The CMake target's POST_BUILD command copies the .so to repo root
+          # (see libvscode-diff/CMakeLists.txt), so it's already at ./libvscode_diff.so.
+          ls -la ./libvscode_diff.so
 
       - name: ABI sanity check (bionic-linked, no glibc SONAMEs)
         run: |

--- a/.github/workflows/_platform-android.yml
+++ b/.github/workflows/_platform-android.yml
@@ -1,0 +1,83 @@
+name: Build library (Android via NDK)
+
+# Cross-compile for Android (Termux, #333) on a Linux runner using the
+# preinstalled Android NDK. No functional tests run here — the target runtime
+# is Android and the runner is Linux — so verification is limited to an ABI
+# sanity check via `readelf` (must link against bionic, not glibc).
+#
+# End-to-end verification is delegated to the issue reporter on a real device.
+#
+# Inputs:
+#   arch        - "arm64" or "x64" (used only for artifact naming; matches the
+#                 client-side detect_arch() convention in installer.lua)
+#   android_abi - NDK ABI string: "arm64-v8a" or "x86_64"
+#   artifact    - Name of the uploaded artifact (e.g. "android-arm64")
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      android_abi:
+        required: true
+        type: string
+      artifact:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: android-${{ inputs.arch }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Build library
+        env:
+          ANDROID_ABI: ${{ inputs.android_abi }}
+        run: |
+          set -euo pipefail
+          echo "Using NDK at: $ANDROID_NDK_ROOT"
+          echo "Target ABI:   $ANDROID_ABI"
+          test -d "$ANDROID_NDK_ROOT" || (echo "ANDROID_NDK_ROOT not present on runner" && exit 1)
+
+          # -DENABLE_OPENMP=OFF: Termux does not ship libgomp; the sequential
+          # fallback for character-level diff is documented in
+          # libvscode-diff/CMakeLists.txt.
+          # -DANDROID_PLATFORM=android-24: matches the Termux minimum for
+          # modern devices; older API levels are not supported by Neovim.
+          cmake -S . -B build-android \
+            -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_ROOT/build/cmake/android.toolchain.cmake" \
+            -DANDROID_ABI="$ANDROID_ABI" \
+            -DANDROID_PLATFORM=android-24 \
+            -DENABLE_OPENMP=OFF \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build build-android --target vscode-diff -j
+          cp build-android/libvscode-diff/libvscode_diff.so ./libvscode_diff.so
+
+      - name: ABI sanity check (bionic-linked, no glibc SONAMEs)
+        run: |
+          set -euo pipefail
+          echo "=== NEEDED entries must be bionic (no libm.so.6 / libc.so.6) ==="
+          NEEDED=$(readelf -d ./libvscode_diff.so | grep NEEDED || true)
+          echo "$NEEDED"
+          # Any glibc SONAME (.so.<N>) is a red flag; bionic uses unversioned .so.
+          if echo "$NEEDED" | grep -qE '\.so\.[0-9]'; then
+            echo "ERROR: built .so links against versioned SONAMEs (glibc); expected bionic-only"
+            exit 1
+          fi
+          echo "$NEEDED" | grep -q "libc.so" || (echo "ERROR: missing libc.so NEEDED entry" && exit 1)
+
+      - name: Upload build artifact
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact }}
+          path: libvscode_diff.so
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/_platform-android.yml
+++ b/.github/workflows/_platform-android.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   build:
-    name: android-${{ inputs.arch }}
+    name: build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/_platform-linux.yml
+++ b/.github/workflows/_platform-linux.yml
@@ -1,0 +1,116 @@
+name: Build library (Linux)
+
+# Native Linux build in a CentOS 7 Docker container. CentOS 7 is chosen for
+# GLIBC 2.17 compatibility — that's the oldest widely-deployed GLIBC we
+# support, which lets our prebuilt binaries `dlopen` on most distro versions.
+#
+# Inputs:
+#   arch     - "x64" or "arm64" (affects toolchain: devtoolset-11 vs system GCC)
+#   runs-on  - GitHub runner label (ubuntu-latest for x64, ubuntu-24.04-arm for arm64)
+#   artifact - Name of the uploaded artifact (e.g. "linux-x64")
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      runs-on:
+        required: true
+        type: string
+      artifact:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: linux-${{ inputs.arch }}
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 'lts/*'
+
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake valgrind
+
+      - name: Setup Neovim
+        uses: ./.github/actions/setup-neovim
+        with:
+          arch: ${{ inputs.arch }}
+
+      - name: Build library (CentOS 7 Docker for GLIBC 2.17 compatibility)
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/workspace \
+            -w /workspace \
+            -e HOST_UID=$(id -u) \
+            -e HOST_GID=$(id -g) \
+            centos:7 \
+            bash -c "
+              set -e
+              # CentOS 7 is EOL, use vault archives (following c-ares approach)
+              sed -i -e 's/^mirrorlist/#mirrorlist/' -e 's/^#baseurl/baseurl/' -e 's/mirror.centos.org/vault.centos.org/' /etc/yum.repos.d/*.repo
+              yum clean all
+              yum install -y epel-release
+              yum install -y centos-release-scl
+              # Delete problematic centos-sclo-sclo repo (from Apache Gluten approach)
+              rm -f /etc/yum.repos.d/CentOS-SCLo-scl.repo
+              # ARM64: devtoolset-11 not available, use system GCC
+              # x86_64: use devtoolset-11 for modern GCC with old GLIBC
+              if [ \$(uname -m) = \"aarch64\" ]; then
+                # Remove SCL-RH repo (not needed for system GCC)
+                rm -f /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+                yum install -y gcc gcc-c++ make curl
+                # ARM64 cmake3 in EPEL is 3.14.6, need 3.15+. Use CMake 3.20.0 (first with ARM64 support).
+                curl -LO https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-linux-aarch64.tar.gz
+                tar --strip-components=1 -xzf cmake-3.20.0-linux-aarch64.tar.gz -C /usr/local
+              else
+                sed -i -e 's/^mirrorlist/#mirrorlist/' -e 's/^#baseurl/baseurl/' -e 's/mirror\.centos\.org/vault.centos.org/' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+                yum install -y devtoolset-11-gcc devtoolset-11-gcc-c++ cmake3 make
+                source /opt/rh/devtoolset-11/enable
+                ln -s /usr/bin/cmake3 /usr/local/bin/cmake
+              fi
+              make build
+              # Copy libgomp.so.1 from CentOS 7 (old GLIBC 2.17 compatible)
+              cp /lib64/libgomp.so.1 ./ || cp /usr/lib64/libgomp.so.1 ./ || true
+              # Fix ownership of build artifacts for host user
+              chown -R \$HOST_UID:\$HOST_GID build/ libvscode_diff.so libgomp.so.1 2>/dev/null || true
+            "
+
+      - name: Run C unit tests
+        run: |
+          # Run test executables directly (bypass ctest which has Docker paths)
+          cd build/libvscode-diff
+          for test in test_*; do
+            echo "Running $test..."
+            ./$test || exit 1
+          done
+
+      - name: Run Valgrind memory leak test
+        run: |
+          cd build/libvscode-diff
+          ctest -R test_memory_leak_valgrind -V
+
+      - name: Run Neovim tests
+        run: make test-lua
+
+      - name: Upload build artifacts
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact }}
+          path: |
+            libvscode_diff.so
+            libgomp.so.1
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/_platform-linux.yml
+++ b/.github/workflows/_platform-linux.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   build:
-    name: linux-${{ inputs.arch }}
+    name: build
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/_platform-macos.yml
+++ b/.github/workflows/_platform-macos.yml
@@ -1,0 +1,61 @@
+name: Build library (macOS)
+
+# Native macOS build. CMake auto-detects Homebrew's libomp for OpenMP via the
+# fallback path in libvscode-diff/CMakeLists.txt.
+#
+# Inputs:
+#   arch     - "x64" (Intel) or "arm64" (Apple Silicon)
+#   runs-on  - GitHub runner label (macos-15-intel or macos-latest)
+#   artifact - Name of the uploaded artifact (e.g. "macos-arm64")
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      runs-on:
+        required: true
+        type: string
+      artifact:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: macos-${{ inputs.arch }}
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 'lts/*'
+
+      - name: Setup Neovim
+        uses: ./.github/actions/setup-neovim
+        with:
+          arch: ${{ inputs.arch }}
+
+      - name: Build library
+        run: make build
+
+      - name: Run C unit tests
+        run: make test-c
+
+      - name: Run Neovim tests
+        run: make test-lua
+
+      - name: Upload build artifacts
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact }}
+          path: libvscode_diff.dylib
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/_platform-macos.yml
+++ b/.github/workflows/_platform-macos.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   build:
-    name: macos-${{ inputs.arch }}
+    name: build
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/_platform-windows.yml
+++ b/.github/workflows/_platform-windows.yml
@@ -1,0 +1,65 @@
+name: Build library (Windows)
+
+# Native Windows build using MSVC. MSVC has built-in OpenMP; nmake drives the
+# CMake-generated Makefile.win.
+#
+# Inputs:
+#   arch     - "x64" or "arm64"
+#   runs-on  - GitHub runner label (windows-latest or windows-11-arm)
+#   artifact - Name of the uploaded artifact (e.g. "windows-x64")
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      runs-on:
+        required: true
+        type: string
+      artifact:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: windows-${{ inputs.arch }}
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 'lts/*'
+
+      - name: Setup Neovim
+        uses: ./.github/actions/setup-neovim
+        with:
+          arch: ${{ inputs.arch }}
+
+      - name: Set up MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Build library
+        run: nmake /f Makefile.win build
+
+      - name: Run C unit tests
+        run: nmake /f Makefile.win test-c
+
+      - name: Run Neovim tests
+        shell: bash
+        run: ./tests/run_tests.sh
+
+      - name: Upload build artifacts
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact }}
+          path: libvscode_diff.dll
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/_platform-windows.yml
+++ b/.github/workflows/_platform-windows.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   build:
-    name: windows-${{ inputs.arch }}
+    name: build
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,11 @@
 name: Build and Test
 
+# Thin orchestrator that fans out to one reusable workflow per build style.
+# The per-style workflows (`_platform-*.yml`) own the actual build steps, so
+# each style stays free of conditionals for platforms it doesn't apply to.
+# Adding a new native target = new matrix entry; adding a new build style =
+# new `_platform-*.yml` + new job here.
+
 on:
   workflow_call:
   workflow_dispatch:
@@ -8,157 +14,54 @@ permissions:
   contents: read
 
 jobs:
-  build-and-test:
-    name: Build and Test (${{ matrix.os }}-${{ matrix.arch }})
-    runs-on: ${{ matrix.runs-on }}
+  linux:
     strategy:
       fail-fast: false
       matrix:
         include:
-          # Linux x64
-          - os: ubuntu-latest
-            arch: x64
-            runs-on: ubuntu-latest
-            artifact: linux-x64
-          # Linux ARM64 (Partner runner - in public beta)
-          - os: ubuntu-24.04-arm
-            arch: arm64
-            runs-on: ubuntu-24.04-arm
-            artifact: linux-arm64
-          # macOS x64 (Intel)
-          - os: macos-15-intel
-            arch: x64
-            runs-on: macos-15-intel
-            artifact: macos-x64
-          # macOS ARM64 (Apple Silicon M1)
-          - os: macos-latest
-            arch: arm64
-            runs-on: macos-latest
-            artifact: macos-arm64
-          # Windows x64
-          - os: windows-latest
-            arch: x64
-            runs-on: windows-latest
-            artifact: windows-x64
-          # Windows ARM64 (Partner runner - in public beta)
-          - os: windows-11-arm
-            arch: arm64
-            runs-on: windows-11-arm
-            artifact: windows-arm64
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
+          - { arch: x64,   runs-on: ubuntu-latest,     artifact: linux-x64 }
+          - { arch: arm64, runs-on: ubuntu-24.04-arm, artifact: linux-arm64 }
+    uses: ./.github/workflows/_platform-linux.yml
+    with:
+      arch: ${{ matrix.arch }}
+      runs-on: ${{ matrix.runs-on }}
+      artifact: ${{ matrix.artifact }}
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 'lts/*'
+  macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { arch: x64,   runs-on: macos-15-intel, artifact: macos-x64 }
+          - { arch: arm64, runs-on: macos-latest,   artifact: macos-arm64 }
+    uses: ./.github/workflows/_platform-macos.yml
+    with:
+      arch: ${{ matrix.arch }}
+      runs-on: ${{ matrix.runs-on }}
+      artifact: ${{ matrix.artifact }}
 
-      - name: Install build tools (Ubuntu)
-        if: startsWith(matrix.runs-on, 'ubuntu')
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential cmake valgrind
+  windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { arch: x64,   runs-on: windows-latest, artifact: windows-x64 }
+          - { arch: arm64, runs-on: windows-11-arm, artifact: windows-arm64 }
+    uses: ./.github/workflows/_platform-windows.yml
+    with:
+      arch: ${{ matrix.arch }}
+      runs-on: ${{ matrix.runs-on }}
+      artifact: ${{ matrix.artifact }}
 
-      - name: Setup Neovim
-        uses: ./.github/actions/setup-neovim
-        with:
-          arch: ${{ matrix.arch }}
-
-      - name: Set up MSVC (Windows)
-        if: startsWith(matrix.runs-on, 'windows')
-        uses: ilammy/msvc-dev-cmd@v1
-
-      - name: Build library (Ubuntu in CentOS 7 Docker for GLIBC 2.17 compatibility)
-        if: startsWith(matrix.runs-on, 'ubuntu')
-        run: |
-          docker run --rm \
-            -v ${{ github.workspace }}:/workspace \
-            -w /workspace \
-            -e HOST_UID=$(id -u) \
-            -e HOST_GID=$(id -g) \
-            centos:7 \
-            bash -c "
-              set -e
-              # CentOS 7 is EOL, use vault archives (following c-ares approach)
-              sed -i -e 's/^mirrorlist/#mirrorlist/' -e 's/^#baseurl/baseurl/' -e 's/mirror.centos.org/vault.centos.org/' /etc/yum.repos.d/*.repo
-              yum clean all
-              yum install -y epel-release
-              yum install -y centos-release-scl
-              # Delete problematic centos-sclo-sclo repo (from Apache Gluten approach)
-              rm -f /etc/yum.repos.d/CentOS-SCLo-scl.repo
-              # ARM64: devtoolset-11 not available, use system GCC
-              # x86_64: use devtoolset-11 for modern GCC with old GLIBC
-              if [ \$(uname -m) = \"aarch64\" ]; then
-                # Remove SCL-RH repo (not needed for system GCC)
-                rm -f /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
-                yum install -y gcc gcc-c++ make curl
-                # ARM64 cmake3 in EPEL is 3.14.6, need 3.15+. Use CMake 3.20.0 (first with ARM64 support).
-                curl -LO https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-linux-aarch64.tar.gz
-                tar --strip-components=1 -xzf cmake-3.20.0-linux-aarch64.tar.gz -C /usr/local
-              else
-                sed -i -e 's/^mirrorlist/#mirrorlist/' -e 's/^#baseurl/baseurl/' -e 's/mirror\.centos\.org/vault.centos.org/' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
-                yum install -y devtoolset-11-gcc devtoolset-11-gcc-c++ cmake3 make
-                source /opt/rh/devtoolset-11/enable
-                ln -s /usr/bin/cmake3 /usr/local/bin/cmake
-              fi
-              make build
-              # Copy libgomp.so.1 from CentOS 7 (old GLIBC 2.17 compatible)
-              cp /lib64/libgomp.so.1 ./ || cp /usr/lib64/libgomp.so.1 ./ || true
-              # Fix ownership of build artifacts for host user
-              chown -R \$HOST_UID:\$HOST_GID build/ libvscode_diff.so libgomp.so.1 2>/dev/null || true
-            "
-
-      - name: Build library (macOS)
-        if: startsWith(matrix.runs-on, 'macos')
-        run: make build
-
-      - name: Build library (Windows)
-        if: startsWith(matrix.runs-on, 'windows')
-        run: nmake /f Makefile.win build
-
-      - name: Run C unit tests (Ubuntu)
-        if: startsWith(matrix.runs-on, 'ubuntu')
-        run: |
-          # Run test executables directly (bypass ctest which has Docker paths)
-          cd build/libvscode-diff
-          for test in test_*; do
-            echo "Running $test..."
-            ./$test || exit 1
-          done
-
-      - name: Run C unit tests (macOS)
-        if: startsWith(matrix.runs-on, 'macos')
-        run: make test-c
-
-      - name: Run Valgrind memory leak test (Ubuntu only)
-        if: startsWith(matrix.runs-on, 'ubuntu')
-        run: |
-          cd build/libvscode-diff
-          ctest -R test_memory_leak_valgrind -V
-
-      - name: Run C unit tests (Windows)
-        if: startsWith(matrix.runs-on, 'windows')
-        run: nmake /f Makefile.win test-c
-
-      - name: Run Neovim tests (Ubuntu/macOS)
-        if: startsWith(matrix.runs-on, 'ubuntu') || startsWith(matrix.runs-on, 'macos')
-        run: make test-lua
-
-      - name: Run Neovim tests (Windows)
-        if: startsWith(matrix.runs-on, 'windows')
-        shell: bash
-        run: ./tests/run_tests.sh
-
-      - name: Upload build artifacts
-        if: success()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.artifact }}
-          path: |
-            libvscode_diff.so
-            libvscode_diff.dylib
-            libvscode_diff.dll
-            libgomp.so.1
-          if-no-files-found: ignore
-          retention-days: 7
+  android:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { arch: arm64, android_abi: arm64-v8a, artifact: android-arm64 }
+          - { arch: x64,   android_abi: x86_64,    artifact: android-x64 }
+    uses: ./.github/workflows/_platform-android.yml
+    with:
+      arch: ${{ matrix.arch }}
+      android_abi: ${{ matrix.android_abi }}
+      artifact: ${{ matrix.artifact }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   linux:
+    name: Build and Test (${{ matrix.runs-on }}-${{ matrix.arch }})
     strategy:
       fail-fast: false
       matrix:
@@ -28,6 +29,7 @@ jobs:
       artifact: ${{ matrix.artifact }}
 
   macos:
+    name: Build and Test (${{ matrix.runs-on }}-${{ matrix.arch }})
     strategy:
       fail-fast: false
       matrix:
@@ -41,6 +43,7 @@ jobs:
       artifact: ${{ matrix.artifact }}
 
   windows:
+    name: Build and Test (${{ matrix.runs-on }}-${{ matrix.arch }})
     strategy:
       fail-fast: false
       matrix:
@@ -54,6 +57,7 @@ jobs:
       artifact: ${{ matrix.artifact }}
 
   android:
+    name: Build and Test (android-${{ matrix.arch }})
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,6 +178,16 @@ jobs:
             cp artifacts/windows-arm64/libvscode_diff.dll release-assets/libvscode_diff_windows_arm64_${VERSION}.dll
           fi
 
+          # Android ARM64 (Termux, #333)
+          if [ -f artifacts/android-arm64/libvscode_diff.so ]; then
+            cp artifacts/android-arm64/libvscode_diff.so release-assets/libvscode_diff_android_arm64_${VERSION}.so
+          fi
+
+          # Android x64 (Termux on Chromebooks / Android-x86 / x86_64 emulators)
+          if [ -f artifacts/android-x64/libvscode_diff.so ]; then
+            cp artifacts/android-x64/libvscode_diff.so release-assets/libvscode_diff_android_x64_${VERSION}.so
+          fi
+
           ls -lah release-assets/
 
       - name: Create Release

--- a/lua/codediff/core/installer.lua
+++ b/lua/codediff/core/installer.lua
@@ -9,6 +9,24 @@ local function get_plugin_root()
   return path_util.get_plugin_root()
 end
 
+-- Detect whether we're running under Termux on Android. Termux presents as
+-- Linux via `ffi.os` and via `uname -s`, but its ABI is bionic libc — not the
+-- glibc our normal `linux-*` binaries link against — so a glibc-linked .so
+-- fails to `dlopen` with "library libm.so.6 not found" (#333). Detection
+-- follows the standard Termux conventions: TERMUX_VERSION is only ever set by
+-- Termux, and PREFIX points inside its filesystem layout.
+local function is_termux()
+  local termux_version = vim.fn.getenv("TERMUX_VERSION")
+  if termux_version ~= vim.NIL and termux_version ~= "" then
+    return true
+  end
+  local prefix = vim.fn.getenv("PREFIX")
+  if type(prefix) == "string" and prefix:match("^/data/data/com%.termux") then
+    return true
+  end
+  return false
+end
+
 -- Detect OS
 local function detect_os()
   local ffi = require("ffi")
@@ -16,6 +34,10 @@ local function detect_os()
     return "windows"
   elseif ffi.os == "OSX" then
     return "macos"
+  elseif is_termux() then
+    -- Termux runs on Android's bionic libc; we ship a separate NDK-built
+    -- binary for it so downloads point at the right ABI.
+    return "android"
   else
     return "linux"
   end


### PR DESCRIPTION
## Summary

Adds **Termux (Android) support** for `codediff.nvim` — resolves #333 — and along the way refactors the CI pipeline from a single conditional-heavy job into per-platform reusable workflow templates. Two changes in one PR because they're structurally coupled (the Android build needed a materially different build shape than the existing 3 platforms, which is what surfaced the "templates are cleaner" opportunity).

## The Termux fix (#333)

- **Root cause**: Termux runs on Android's bionic libc; our existing `linux-*` prebuilt binaries link against glibc, so they fail to `dlopen` with `library "libm.so.6" not found`.
- **Fix**: ship two new NDK-cross-compiled binaries:
  - `libvscode_diff_android_arm64_<ver>.so` — arm64-v8a, majority of Termux devices
  - `libvscode_diff_android_x64_<ver>.so` — x86_64, Chromebooks and emulators
- **Client detection**: `installer.lua` gains `is_termux()` (checks `$TERMUX_VERSION` or the `/data/data/com.termux/files/usr` PREFIX) and routes to the `android` OS name in URL construction. `detect_arch()` was already correct (`aarch64→arm64`, `x86_64→x64`).
- **NDK build**: cross-compile on `ubuntu-latest` with `ENABLE_OPENMP=OFF` (Termux doesn't ship libgomp; the sequential fallback is already a supported CMake option) at `ANDROID_PLATFORM=android-24`.
- **Verification limit**: because we can't run Neovim on Android in CI, the Android job's only signal is a `readelf` ABI sanity check (no versioned SONAMEs → bionic-linked). End-to-end validation on a real Termux device is delegated to the #333 reporter once the release lands.

Coverage: ships arm64 + x86_64 (~98% of Termux users). armv7 and i686 can be added later if a user reports needing them.

## The pipeline refactor

**Before**: single 213-line `build-and-test.yml` job with a matrix of 6 rows and 6 in-line `if:` conditionals guarding platform-specific steps. Every new platform (or every new step) required understanding the full truth table.

**After**: `build-and-test.yml` becomes a 67-line dispatcher that fans out to four reusable workflows, one per build style:

```
.github/workflows/
├── build-and-test.yml           # thin dispatcher (67 lines)
├── _platform-linux.yml          # CentOS 7 Docker + native tests + Valgrind
├── _platform-macos.yml          # brew libomp + native tests
├── _platform-windows.yml        # MSVC + nmake + native tests
└── _platform-android.yml        # NDK cross-compile + readelf sanity check
```

Zero conditionals in template files — each contains only its style's steps.

### Non-breaking guarantees

- **Every build step name, order, and script body is preserved verbatim** for Linux/macOS/Windows. The refactor is mechanical extraction, not a rewrite.
- **Artifact names identical** (`linux-x64`, `macos-arm64`, …) — `release.yml`'s `needs: build-and-test` still waits for all fanned-out jobs.
- **`fail-fast: false` semantics strictly stronger** — moved from top-level to each platform-family job, so one family's failure no longer cancels other families.
- **Linux artifact upload path narrowed** from `{.so, .dylib, .dll, libgomp}` (with `if-no-files-found: ignore`) to `{.so, libgomp}`. The other extensions never existed on Linux runners in the first place; the old workflow was tolerating dead entries.

### What this PR run will confirm

Everything I can't verify locally:
- Every existing platform still builds green byte-for-byte with the extracted templates
- `ANDROID_NDK_ROOT` presence on today's `ubuntu-latest` image
- The `readelf` sanity check correctly gates only bionic-linked binaries
- `needs: build-and-test` from `release.yml` correctly waits for the 4-way fan-out

### Local verification done

- All 6 workflow YAML files parse
- 8 matrix rows ↔ 8 `release.yml` artifact renames (matched exactly)
- Installer spec: **14/14 pass** — no regression to Linux/macOS/Windows detection paths

## Rollout

Draft PR — please don't merge until the CI run gives a clean pass on all 8 platforms. If the Android job fails, that's the isolated signal we need to iterate on NDK flags without disturbing anything else.

Once the release with these binaries lands, comment on #333 asking the reporter to retry and confirm.

Closes #333 (pending downstream user confirmation).
