### PR TITLE
fix(compact): apply diff.compact default when opening from the explorer (#496)

### DIFF
--- a/lua/codediff/ui/view/compact.lua
+++ b/lua/codediff/ui/view/compact.lua
@@ -331,7 +331,13 @@ function M.refresh(tabpage)
 
   -- Open in compact mode by default (config) once, when the first real diff is
   -- ready. Afterwards compact follows the user's gc toggle for the session.
-  if not session.compact_default_applied and session.stored_diff_result then
+  --
+  -- The `.changes` check is what encodes "real diff is ready" — an explorer/
+  -- history session starts life with `stored_diff_result = {}` as a placeholder,
+  -- and `setup_all_keymaps` calls `M.refresh` before any file has been picked
+  -- (#496). Without the extra clause, the truthy `{}` would burn the one-shot
+  -- latch there and no later file selection could ever apply the default.
+  if not session.compact_default_applied and session.stored_diff_result and session.stored_diff_result.changes then
     session.compact_default_applied = true
     local changes = session.stored_diff_result.changes
     local is_conflict = session.result_win ~= nil and vim.api.nvim_win_is_valid(session.result_win)

--- a/tests/ui/explorer/issue_496_spec.lua
+++ b/tests/ui/explorer/issue_496_spec.lua
@@ -1,0 +1,108 @@
+-- Regression test for https://github.com/esmuellert/codediff.nvim/issues/496
+-- `diff.compact = true` must also apply when the first file is selected from
+-- the explorer, not just when a diff is opened directly.
+--
+-- Pre-fix: the explorer's placeholder session had `stored_diff_result = {}`.
+-- `setup_all_keymaps` called `compact.refresh` immediately after session
+-- creation, and the guard `not compact_default_applied and stored_diff_result`
+-- evaluated the truthy `{}` and burned the one-shot latch. When the user then
+-- selected a file, the second `compact.refresh` call skipped `M.enable` because
+-- the latch was already set.
+
+local h = require("tests.helpers")
+
+describe("Issue #496 regression — diff.compact default applies on explorer select", function()
+  local repo
+  local lifecycle = require("codediff.ui.lifecycle")
+
+  before_each(function()
+    h.ensure_plugin_loaded()
+    require("codediff").setup({ diff = { compact = true, compact_context_lines = 3 } })
+    lifecycle.cleanup_all()
+    repo = h.create_temp_git_repo()
+
+    -- File big enough to have foldable unchanged regions when compact is on.
+    repo.write_file("file.txt", {
+      "l1", "l2", "l3", "l4", "l5", "l6", "l7", "l8", "l9", "l10",
+      "l11", "l12", "l13", "l14", "l15", "l16", "l17", "l18", "l19", "l20",
+    })
+    repo.git("add .")
+    repo.git("commit -m c")
+    -- Single-line change in the middle → 2 folded regions above and below.
+    repo.write_file("file.txt", {
+      "l1", "l2", "l3", "l4", "l5", "l6", "l7", "l8", "l9", "l10",
+      "CHANGED",
+      "l12", "l13", "l14", "l15", "l16", "l17", "l18", "l19", "l20",
+    })
+  end)
+
+  after_each(function()
+    h.close_extra_tabs()
+    lifecycle.cleanup_all()
+    if repo then repo.cleanup() end
+    -- Reset compact so subsequent tests don't inherit our test's true value.
+    require("codediff").setup({ diff = { compact = false } })
+  end)
+
+  it("compact_mode is enabled after selecting a file from :CodeDiff explorer", function()
+    vim.cmd("edit " .. repo.path("file.txt"))
+    require("codediff.commands").vscode_diff({ fargs = {} })
+
+    -- Wait for the explorer to open with a current selection.
+    local explorer
+    assert.is_true(vim.wait(8000, function()
+      for _, tp in ipairs(vim.api.nvim_list_tabpages()) do
+        local sess = lifecycle.get_session(tp)
+        if sess and sess.explorer and sess.explorer.current_file_path ~= nil then
+          explorer = sess.explorer
+          return true
+        end
+      end
+      return false
+    end, 50), "explorer did not open with a current file selection")
+
+    -- Wait for the real diff to land (stored_diff_result.changes populated),
+    -- then for compact.refresh to see it and enable compact mode.
+    local tabpage = explorer.tabpage
+    local compact_on = vim.wait(8000, function()
+      local sess = lifecycle.get_session(tabpage)
+      return sess and sess.compact_mode == true
+    end, 50)
+
+    local sess = lifecycle.get_session(tabpage)
+    assert.is_not_nil(sess)
+    -- Pre-fix: compact_mode was nil (latch got burned on the placeholder).
+    assert.is_true(compact_on,
+      "diff.compact=true default did not apply to explorer-selected file; "
+        .. "compact_mode=" .. tostring(sess.compact_mode)
+        .. " compact_default_applied=" .. tostring(sess.compact_default_applied)
+        .. " has_changes=" .. tostring(sess.stored_diff_result and sess.stored_diff_result.changes ~= nil))
+  end)
+
+  it("compact_default_applied stays false until a real diff is loaded", function()
+    -- Guard against a future regression that flips the latch on any truthy
+    -- `stored_diff_result` again — the placeholder must not burn the one-shot.
+    vim.cmd("edit " .. repo.path("file.txt"))
+    require("codediff.commands").vscode_diff({ fargs = {} })
+
+    -- Between session creation and the first file selection, the placeholder
+    -- session exists but has no real diff yet. Snapshot the latch immediately
+    -- after session creation — it should still be nil/false at that point.
+    local placeholder_seen = vim.wait(4000, function()
+      for _, tp in ipairs(vim.api.nvim_list_tabpages()) do
+        local sess = lifecycle.get_session(tp)
+        if sess and sess.stored_diff_result then
+          -- Snapshot: at this instant, has the latch been burned inappropriately?
+          if sess.stored_diff_result.changes == nil then
+            -- Placeholder frame: compact_default_applied MUST still be nil/false.
+            assert.is_falsy(sess.compact_default_applied,
+              "compact_default_applied was set on the placeholder session (regression of #496)")
+            return true
+          end
+        end
+      end
+      return false
+    end, 50)
+    assert.is_true(placeholder_seen, "never observed a placeholder session frame to inspect")
+  end)
+end)


### PR DESCRIPTION
Closes #496.

## Summary

`diff.compact = true` didn't take effect for files opened via the explorer (only for direct `:CodeDiff file HEAD`-style diffs). This PR fixes it with a one-line change and adds regression coverage.

## Root cause

Explorer/history diffs create a **placeholder session** in `side_by_side.lua` with `stored_diff_result = {}` — the buffers, keymaps, and lifecycle need a real session object before any file has been selected. Right after that session is created, `setup_all_keymaps` calls `compact.refresh(tabpage)`.

The one-shot latch in `M.refresh` looked like this:

```lua
if not session.compact_default_applied and session.stored_diff_result then
  session.compact_default_applied = true
  ...
end
```

`{}` is truthy in Lua, so on the placeholder frame the latch got burned to `true` while `.changes` was still `nil` and `M.enable` wasn't called. When the user later selected a file and the real diff rendered, the second `compact.refresh` hit `session.compact_default_applied == true` and skipped `M.enable` entirely.

## Fix

One line — bring the latch under the same `.changes` guard that every other consumer of `stored_diff_result` in `compact.lua` already uses:

```diff
- if not session.compact_default_applied and session.stored_diff_result then
+ if not session.compact_default_applied
+     and session.stored_diff_result
+     and session.stored_diff_result.changes then
```

`.changes` is the real "diff has been computed" signal — it's what the block already reads on the next line, and it's what `M.enable`, `M.disable`, `M.toggle`, and the fold-computation path all key off. The buggy line was the only place in the file that stopped at the outer table.

Also fleshed out the block's comment to record why the extra clause is needed, so a future refactor doesn't drop it back.

## Testing

New spec: `tests/ui/explorer/issue_496_spec.lua`, 2 cases:

1. **Positive:** open `:CodeDiff` with `diff.compact = true`, select a file, assert `session.compact_mode == true`.
2. **Invariant guard:** assert `session.compact_default_applied` stays false on the placeholder frame (catches a re-introduction of the same class of bug).

Verified: both cases **fail without the fix**, **pass with the fix**.

Full regression sweep — no failures across:

| Spec | Result |
|------|--------|
| `tests/ui/view/compact_spec.lua` | 30/30 |
| `tests/ui/explorer/issue_496_spec.lua` | 2/2 (new) |
| `tests/ui/explorer/explorer_spec.lua` | 22/22 |
| `tests/ui/explorer/explorer_staging_spec.lua` | 8/8 |
| `tests/ui/explorer/hunk_operations_spec.lua` | 14/14 |
| `tests/ui/view/layout_toggle_spec.lua` | 13/13 |
| `tests/ui/view/view_spec.lua` | 17/17 |

## Compatibility

No behavior change for any working code path — the `M.enable` call is still gated by the same conditions (`config.options.diff.compact`, `not is_conflict`, `#changes > 0`). Sessions that never populate `.changes` (e.g. a placeholder that gets closed without a file selection) will now correctly leave the latch unburned, so if compact was intended to fire it still can on the next real refresh.
