### PR TITLE
ci: name build jobs after the target they build

### DIFF
--- a/.github/workflows/_platform-android.yml
+++ b/.github/workflows/_platform-android.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   build:
-    name: build
+    name: ${{ inputs.artifact }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/_platform-linux.yml
+++ b/.github/workflows/_platform-linux.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   build:
-    name: build
+    name: ${{ inputs.artifact }}
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/_platform-macos.yml
+++ b/.github/workflows/_platform-macos.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   build:
-    name: build
+    name: ${{ inputs.artifact }}
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/_platform-windows.yml
+++ b/.github/workflows/_platform-windows.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   build:
-    name: build
+    name: ${{ inputs.artifact }}
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   linux:
-    name: Build and Test (${{ matrix.runs-on }}-${{ matrix.arch }})
+    name: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
@@ -29,7 +29,7 @@ jobs:
       artifact: ${{ matrix.artifact }}
 
   macos:
-    name: Build and Test (${{ matrix.runs-on }}-${{ matrix.arch }})
+    name: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
@@ -43,7 +43,7 @@ jobs:
       artifact: ${{ matrix.artifact }}
 
   windows:
-    name: Build and Test (${{ matrix.runs-on }}-${{ matrix.arch }})
+    name: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
@@ -57,7 +57,7 @@ jobs:
       artifact: ${{ matrix.artifact }}
 
   android:
-    name: Build and Test (android-${{ matrix.arch }})
+    name: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -57,7 +57,7 @@ jobs:
       artifact: ${{ matrix.artifact }}
 
   android:
-    name: ubuntu-latest
+    name: ubuntu-latest (${{ matrix.android_abi }})
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

The Actions run sidebar shows eight identical `build` entries with no way to tell the platforms apart:

<img width="300" alt="eight jobs all named build" src="https://github.com/user-attachments/assets/placeholder" />

GitHub renders the **innermost** job name in that list, and every `_platform-*.yml` hardcodes `name: build`. The only distinguishing text lives one level up, in `build-and-test.yml`, which the sidebar does not show:

```
pr.yml
 └─ build-and-test                                              → segment 1
     build-and-test.yml
      └─ Build and Test (${{ matrix.runs-on }}-${{ matrix.arch }})  → segment 2
          _platform-{linux,macos,windows,android}.yml
           └─ build          ← hardcoded, identical ×4          → segment 3, shown in the sidebar
```

## Changes

- **Leaf jobs** are named after the artifact they produce, so the sidebar can tell them apart. `matrix.artifact` already carried the clean canonical name and was only being used for upload.
- **Caller jobs** are named after the runner. The old name concatenated `runs-on` and `arch`, which repeat each other: `ubuntu-24.04-arm-arm64`, `macos-15-intel-x64`.

The full check name now reads as runner then target:

| | before | after |
|---|---|---|
| sidebar | `build` ×8 | `linux-x64`, `linux-arm64`, `macos-x64`, `macos-arm64`, `windows-x64`, `windows-arm64`, `android-arm64`, `android-x64` |
| check name | `build-and-test / Build and Test (ubuntu-24.04-arm-arm64) / build` | `build-and-test / ubuntu-24.04-arm / linux-arm64` |

Eight lines changed; no build logic touched.

## ⚠️ Requires a ruleset update in the same change

This renames the eight `build-and-test` status contexts. The **"Require status checks"** ruleset (active on `main` and `next`) pins the old strings:

```
build-and-test / Build and Test (ubuntu-latest-x64) / build
build-and-test / Build and Test (ubuntu-24.04-arm-arm64) / build
build-and-test / Build and Test (macos-15-intel-x64) / build
build-and-test / Build and Test (macos-latest-arm64) / build
build-and-test / Build and Test (windows-latest-x64) / build
build-and-test / Build and Test (windows-11-arm-arm64) / build
build-and-test / Build and Test (android-arm64) / build
build-and-test / Build and Test (android-x64) / build
```

Those contexts stop reporting once this merges, so they must be replaced with:

```
build-and-test / ubuntu-latest / linux-x64
build-and-test / ubuntu-24.04-arm / linux-arm64
build-and-test / macos-15-intel / macos-x64
build-and-test / macos-latest / macos-arm64
build-and-test / windows-latest / windows-x64
build-and-test / windows-11-arm / windows-arm64
build-and-test / ubuntu-latest (arm64-v8a) / android-arm64
build-and-test / ubuntu-latest (x86_64) / android-x64
```

**Until the ruleset is updated, this PR itself will sit blocked on the old contexts.** Auto-merge is intentionally not enabled for that reason.

`standalone-build-test` and `regression-check` contexts are unchanged and stay in the ruleset as they are.

## Testing

All workflow YAML parses. The rename affects job labels only — no `runs-on`, no steps, no artifact names, and no `needs:` edges are touched, so artifact upload and download in the release workflow are unaffected.

