### PR TITLE
fix(scrollsync): prevent TreeSitter follower redraws from moving the active cursor

### DIFF
--- a/lua/codediff/scrollsync.lua
+++ b/lua/codediff/scrollsync.lua
@@ -154,6 +154,21 @@ local function win_view(w)
   return api.nvim_win_call(w, vim.fn.winsaveview)
 end
 
+local function changed_windows(event, first)
+  local changed = {}
+  for key in pairs(event or {}) do
+    local win = tonumber(key)
+    if win then
+      changed[win] = true
+    end
+  end
+  local first_win = tonumber(first)
+  if first_win then
+    changed[first_win] = true
+  end
+  return next(changed) and changed or nil
+end
+
 function Group:_valid_wins()
   local out = {}
   for _, w in ipairs(self.wins) do
@@ -182,6 +197,7 @@ function Group:refresh()
   end
   -- Fill tables changed; stored fingerprints are stale.
   self.expected = {}
+  self.pending_echo = {}
 end
 
 --- Align every window other than `leader` to `leader`'s virtual-row position.
@@ -196,6 +212,7 @@ function Group:_apply(leader, jump)
   if not ftl then
     return
   end
+  self.pending_echo[leader] = nil
   local lv = win_view(leader)
   local vrow = view_to_vrow(ftl, lv.topline, lv.topfill)
   self.vrow = vrow
@@ -222,6 +239,7 @@ function Group:_apply(leader, jump)
         local delta = target_top_vrow - cur_top_vrow
 
         if delta ~= 0 then
+          self.pending_echo[w] = true
           if not jump then
             -- Relative scroll (<C-e>/<C-y>) preserves the grid_scroll
             -- optimization so the follower is not fully repainted.
@@ -244,6 +262,7 @@ function Group:_apply(leader, jump)
         -- Mirror horizontal scroll (leftcol) without disturbing the vertical view.
         local fv = win_view(w)
         if (fv.leftcol or 0) ~= leftcol then
+          self.pending_echo[w] = true
           api.nvim_win_call(w, function()
             local v = vim.fn.winsaveview()
             v.leftcol = leftcol
@@ -284,26 +303,45 @@ end
 --- topfill-only scrolls and mouse scrolls of a non-focused window, and it
 --- ignores the echo scroll events produced by our own winrestview (their
 --- fingerprint matches `expected`).
-function Group:_detect_leader()
+function Group:_detect_leader(changed)
   local cur = api.nvim_get_current_win()
   local candidate
   for _, w in ipairs(self:_valid_wins()) do
-    local fp = view_fp(win_view(w))
-    if fp ~= self.expected[w] then
-      if w == cur then
-        return w -- prefer the focused window when it moved
+    if not changed or changed[w] then
+      local fp = view_fp(win_view(w))
+      if fp ~= self.expected[w] then
+        if w == cur then
+          return w -- prefer the focused window when it moved
+        end
+        candidate = candidate or w
       end
-      candidate = candidate or w
     end
   end
   return candidate
 end
 
-function Group:_on_scroll()
-  if self.syncing or self.paused then
+function Group:_consume_pending_echoes(changed)
+  if not changed then
     return
   end
-  local leader = self:_detect_leader()
+  local current = api.nvim_get_current_win()
+  for w in pairs(changed) do
+    if w ~= current and self.pending_echo[w] then
+      self.pending_echo[w] = nil
+      self.expected[w] = view_fp(win_view(w))
+    end
+  end
+end
+
+function Group:_on_scroll(changed)
+  if self.syncing then
+    return
+  end
+  self:_consume_pending_echoes(changed)
+  if self.paused then
+    return
+  end
+  local leader = self:_detect_leader(changed)
   if not leader then
     return
   end
@@ -352,6 +390,7 @@ function M.bind(opts)
     wins = vim.deepcopy(opts.wins),
     ft = {},
     expected = {},
+    pending_echo = {},
     syncing = false,
     paused = false,
     active = true,
@@ -368,12 +407,12 @@ function M.bind(opts)
   self.augroup = api.nvim_create_augroup("codediff_scrollsync_" .. tostring(self):gsub("%W", ""), { clear = true })
   api.nvim_create_autocmd("WinScrolled", {
     group = self.augroup,
-    callback = function()
+    callback = function(args)
       if not self.active then
         return
       end
       -- Only react when a member window is involved.
-      self:_on_scroll()
+      self:_on_scroll(changed_windows(vim.v.event, args.match))
     end,
   })
   -- A height change alters the topfill clamp; re-align to stay consistent.
@@ -407,6 +446,7 @@ end
 -- Exposed for tests.
 M._internal = {
   build_fill_table = build_fill_table,
+  changed_windows = changed_windows,
   vrow_of_line = vrow_of_line,
   view_to_vrow = view_to_vrow,
   vrow_to_view = vrow_to_view,

--- a/lua/codediff/scrollsync.lua
+++ b/lua/codediff/scrollsync.lua
@@ -385,6 +385,9 @@ end
 function Group:resume()
   self.paused = false
   self:resync()
+  for w in pairs(self.saved_scrolloff) do
+    self:_restore_scrolloff(w)
+  end
 end
 
 --- Tear down: remove autocmds and mark inactive.

--- a/lua/codediff/scrollsync.lua
+++ b/lua/codediff/scrollsync.lua
@@ -188,9 +188,23 @@ function Group:_is_member(w)
   return false
 end
 
+function Group:_restore_scrolloff(w)
+  local saved = self.saved_scrolloff[w]
+  if saved == nil then
+    return
+  end
+  self.saved_scrolloff[w] = nil
+  if api.nvim_win_is_valid(w) then
+    api.nvim_set_option_value("scrolloff", saved, { win = w, scope = "local" })
+  end
+end
+
 --- Rebuild the per-window fill tables from current buffer fillers. Call after
 --- the diff/fillers are re-rendered.
 function Group:refresh()
+  for w in pairs(self.saved_scrolloff) do
+    self:_restore_scrolloff(w)
+  end
   self.ft = {}
   for _, w in ipairs(self:_valid_wins()) do
     self.ft[w] = build_fill_table(api.nvim_win_get_buf(w))
@@ -213,6 +227,7 @@ function Group:_apply(leader, jump)
     return
   end
   self.pending_echo[leader] = nil
+  self:_restore_scrolloff(leader)
   local lv = win_view(leader)
   local vrow = view_to_vrow(ftl, lv.topline, lv.topfill)
   self.vrow = vrow
@@ -253,8 +268,13 @@ function Group:_apply(leader, jump)
           -- scroll fell short (e.g. near the top/bottom of the buffer).
           local after = win_view(w)
           if jump or after.topline ~= target_tl or (after.topfill or 0) ~= target_tf then
+            local scrolloff = api.nvim_get_option_value("scrolloff", { win = w })
+            if scrolloff > 0 and self.saved_scrolloff[w] == nil then
+              self.saved_scrolloff[w] = api.nvim_get_option_value("scrolloff", { win = w, scope = "local" })
+              api.nvim_set_option_value("scrolloff", 0, { win = w, scope = "local" })
+            end
             api.nvim_win_call(w, function()
-              vim.fn.winrestview({ topline = target_tl, topfill = target_tf })
+              vim.fn.winrestview({ topline = target_tl, topfill = target_tf, lnum = target_tl })
             end)
           end
         end
@@ -328,6 +348,7 @@ function Group:_consume_pending_echoes(changed)
   for w in pairs(changed) do
     if w ~= current and self.pending_echo[w] then
       self.pending_echo[w] = nil
+      self:_restore_scrolloff(w)
       self.expected[w] = view_fp(win_view(w))
     end
   end
@@ -372,6 +393,9 @@ function Group:unbind()
     pcall(api.nvim_del_augroup_by_id, self.augroup)
     self.augroup = nil
   end
+  for w in pairs(self.saved_scrolloff) do
+    self:_restore_scrolloff(w)
+  end
   self.active = false
 end
 
@@ -391,6 +415,7 @@ function M.bind(opts)
     ft = {},
     expected = {},
     pending_echo = {},
+    saved_scrolloff = {},
     syncing = false,
     paused = false,
     active = true,

--- a/tests/scrollsync_spec.lua
+++ b/tests/scrollsync_spec.lua
@@ -37,6 +37,11 @@ describe("scrollsync virtual-row mapping", function()
     assert.equals(6, internal.vrow_of_line(ft, 4))
   end)
 
+  it("collects changed window IDs from WinScrolled data", function()
+    assert.same({ [12] = true, [13] = true, [14] = true }, internal.changed_windows({ all = {}, ["12"] = {}, [13] = {} }, "14"))
+    assert.is_nil(internal.changed_windows({}, ""))
+  end)
+
   it("vrow_to_view is the inverse of view_to_vrow", function()
     local _, buf = make_win({ "a", "b", "c", "d", "e", "f" }, { { after = 3, count = 4 } })
     local ft = internal.build_fill_table(buf)
@@ -91,6 +96,26 @@ describe("scrollsync manager alignment", function()
     end
     local win_right = make_win(right, {})
     return win_left, win_right
+  end
+
+  local function set_view(win, topline, cursor_line)
+    vim.api.nvim_win_call(win, function()
+      vim.fn.winrestview({ topline = topline, lnum = cursor_line })
+    end)
+  end
+
+  local function fire_win_scrolled(group, win)
+    group:_on_scroll({ [win] = true })
+  end
+
+  local function setup_pending_follower_echo()
+    local follower, leader = setup_pair()
+    local group = scroll.bind(tab, { follower, leader })
+    vim.api.nvim_set_current_win(leader)
+    set_view(leader, 35, 40)
+    group:resync(leader)
+    group.pending_echo[follower] = true
+    return { group = group, leader = leader, follower = follower }
   end
 
   it("binds windows and keeps native scrollbind off", function()
@@ -179,6 +204,58 @@ describe("scrollsync manager alignment", function()
     -- Follower topline must be (weakly) monotonic while scrolling down; any
     -- large backwards jump would be the scrollbind oscillation.
     assert.is_true(max_backjump <= 1, "follower topline should not oscillate; max backward jump was " .. max_backjump)
+  end)
+
+  it("waits for the pending follower's own WinScrolled event", function()
+    local scenario = setup_pending_follower_echo()
+
+    fire_win_scrolled(scenario.group, scenario.leader)
+    assert.is_true(
+      scenario.group.pending_echo[scenario.follower],
+      "another window must not consume the follower's echo"
+    )
+
+    fire_win_scrolled(scenario.group, scenario.follower)
+    assert.is_nil(
+      scenario.group.pending_echo[scenario.follower],
+      "the follower's own event must consume its echo"
+    )
+  end)
+
+  it("keeps the active leader fixed when a follower redraw corrects its view", function()
+    local scenario = setup_pending_follower_echo()
+    local leader_before = view(scenario.leader)
+    set_view(scenario.follower, 10, 20)
+
+    fire_win_scrolled(scenario.group, scenario.follower)
+
+    local leader_after = view(scenario.leader)
+    assert.equals(leader_before.topline, leader_after.topline, "follower redraw must not move the leader")
+    assert.equals(
+      leader_before.topfill,
+      leader_after.topfill,
+      "follower redraw must not change the leader's filler offset"
+    )
+  end)
+
+  it("treats a later non-focused follower scroll as user input", function()
+    local scenario = setup_pending_follower_echo()
+    fire_win_scrolled(scenario.group, scenario.follower)
+    assert.is_nil(
+      scenario.group.pending_echo[scenario.follower],
+      "the programmatic echo must be consumed first"
+    )
+    local leader_before = view(scenario.leader)
+    set_view(scenario.follower, 10, 20)
+
+    fire_win_scrolled(scenario.group, scenario.follower)
+
+    local leader_after = view(scenario.leader)
+    assert.not_equal(
+      leader_before.topline,
+      leader_after.topline,
+      "later user scrolling in the follower must move the leader"
+    )
   end)
 
   it("syncs three panes together (conflict/merge view)", function()

--- a/tests/scrollsync_spec.lua
+++ b/tests/scrollsync_spec.lua
@@ -76,19 +76,20 @@ describe("scrollsync manager alignment", function()
     pcall(vim.cmd, "tabclose")
   end)
 
-  local function setup_pair()
+  local function setup_pair(insert_count)
+    insert_count = insert_count or 30
     -- left = "delete" side (30 real lines + a 30-filler block replaced), right normal
     local left = {}
     for i = 1, 60 do
       left[i] = string.format("C%03d", i)
     end
-    local win_left = make_win(left, { { after = 20, count = 30 } })
+    local win_left = make_win(left, { { after = 20, count = insert_count } })
     vim.cmd("rightbelow vsplit")
     local right = {}
     for i = 1, 20 do
       right[i] = string.format("C%03d", i)
     end
-    for k = 0, 29 do
+    for k = 0, insert_count - 1 do
       right[20 + k + 1] = string.format("I%03d", k)
     end
     for i = 21, 60 do
@@ -236,6 +237,29 @@ describe("scrollsync manager alignment", function()
       leader_after.topfill,
       "follower redraw must not change the leader's filler offset"
     )
+  end)
+
+  it("keeps the follower on the aligned baseline after leaving a full-screen filler", function()
+    local follower, leader = setup_pair(214)
+    local group = scroll.bind(tab, { follower, leader })
+    vim.api.nvim_set_current_win(leader)
+    vim.wo[follower].scrolloff = 8
+    set_view(follower, 21, 21)
+    set_view(leader, 21, 25)
+    group:resync(leader)
+    fire_win_scrolled(group, follower)
+
+    set_view(leader, 20, 24)
+    fire_win_scrolled(group, leader)
+    local follower_view = view(follower)
+    local follower_cursor = vim.api.nvim_win_get_cursor(follower)[1]
+
+    assert.is_true(follower_cursor >= follower_view.topline, "the follower cursor must remain in the aligned view")
+    assert.equals(0, vim.wo[follower].scrolloff, "the follower view must remain stable until its redraw")
+    fire_win_scrolled(group, follower)
+    vim.cmd("redraw")
+    assert.equals(8, vim.wo[follower].scrolloff, "the follower's scrolloff must be restored after its redraw")
+    assert.equals(20, view(follower).topline, "the follower must not flash unrelated baseline text")
   end)
 
   it("treats a later non-focused follower scroll as user input", function()


### PR DESCRIPTION
## Summary

Prevent TreeSitter redraws in a virtual follower buffer from moving the active cursor during structural scroll synchronization, while keeping the follower aligned as it leaves a full-screen filler block.

## Root cause

CodeDiff records the expected view after programmatically scrolling a follower pane. TreeSitter can then correct the virtual buffer's final view while rendering a tall `virt_lines` filler block. The resulting `WinScrolled` echo previously looked like independent follower scrolling, so CodeDiff promoted that pane to leader and synchronized its clamped position back to the active pane.

An exact follower correction can also be displaced by local `scrolloff` before the redraw echo arrives, briefly exposing unrelated baseline text.

The regression was introduced by [#471](https://github.com/esmuellert/codediff.nvim/pull/471), which added structural scroll synchronization.

## Changes

- Track programmatic follower scrolls until their own `WinScrolled` event arrives.
- Use the changed window IDs from `v:event` and the callback match to consume only the relevant follower echo.
- Record TreeSitter's corrected final follower view without synchronizing it back to the active pane.
- Temporarily suppress follower `scrolloff` during exact filler alignment, then restore it on redraw, resume, refresh, or teardown.
- Preserve subsequent non-focused follower scrolling and move-alignment resume behavior.
- Add focused coverage for echo ownership, redraw corrections, full-screen filler alignment, stale pending state, and later non-focused scrolling.

## Benefits

- Keeps the active cursor stable around tall filler blocks in TreeSitter-highlighted virtual buffers.
- Prevents the follower from flashing unrelated baseline text when leaving a full-screen filler.
- Preserves structural scroll synchronization, non-focused mouse scrolling, and user window options.
- Avoids disabling TreeSitter or syntax highlighting in revision buffers.

## Demonstration

### Before

https://github.com/user-attachments/assets/15ffc732-e74e-4396-9b37-cfa871cc3664

### After

https://github.com/user-attachments/assets/3d5cefd2-4e11-4245-a780-15b79c37f031
